### PR TITLE
allow union input to `json_get`

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -107,7 +107,7 @@ pub fn invoke<C: FromIterator<Option<I>> + 'static, I>(
             Ok(ColumnarValue::Scalar(to_scalar(v)))
         }
         ColumnarValue::Scalar(_) => {
-            exec_err!("unexpected first argument type, expected string")
+            exec_err!("unexpected first argument type, expected string or JSON union")
         }
     }
 }

--- a/src/common_union.rs
+++ b/src/common_union.rs
@@ -1,8 +1,8 @@
 use std::sync::{Arc, OnceLock};
 
-use arrow::array::{Array, ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, StructArray, UnionArray};
+use arrow::array::{Array, ArrayRef, BooleanArray, Float64Array, Int64Array, StringArray, UnionArray};
 use arrow::buffer::Buffer;
-use arrow_schema::{DataType, Field, Fields, UnionFields, UnionMode};
+use arrow_schema::{DataType, Field, UnionFields, UnionMode};
 use datafusion_common::ScalarValue;
 
 pub(crate) fn is_json_union(data_type: &DataType) -> bool {
@@ -12,13 +12,16 @@ pub(crate) fn is_json_union(data_type: &DataType) -> bool {
     }
 }
 
-pub(crate) fn nested_json_struct(array: &ArrayRef) -> Option<&StructArray> {
+/// Extract nested JSON from a `JsonUnion` `UnionArray`
+///
+/// # Arguments
+/// * `array` - The `UnionArray` to extract the nested JSON from
+/// * `object_lookup` - If `true`, extract from the "object" member of the union,
+///   otherwise extract from the "array" member
+pub(crate) fn nested_json_array(array: &ArrayRef, object_lookup: bool) -> Option<&StringArray> {
     let union_array: &UnionArray = array.as_any().downcast_ref::<UnionArray>()?;
-    union_array.child(TYPE_ID_JSON).as_any().downcast_ref()
-}
-
-pub(crate) fn extract_nested_json(struct_array: &StructArray) -> Option<&StringArray> {
-    struct_array.column_by_name("nested_json")?.as_any().downcast_ref()
+    let type_id = if object_lookup { TYPE_ID_OBJECT } else { TYPE_ID_ARRAY };
+    union_array.child(type_id).as_any().downcast_ref()
 }
 
 #[derive(Debug)]
@@ -28,7 +31,8 @@ pub(crate) struct JsonUnion {
     ints: Vec<Option<i64>>,
     floats: Vec<Option<f64>>,
     strings: Vec<Option<String>>,
-    json: Vec<Option<(bool, String)>>,
+    arrays: Vec<Option<String>>,
+    objects: Vec<Option<String>>,
     type_ids: Vec<i8>,
     index: usize,
     capacity: usize,
@@ -42,7 +46,8 @@ impl JsonUnion {
             ints: vec![None; capacity],
             floats: vec![None; capacity],
             strings: vec![None; capacity],
-            json: vec![None; capacity],
+            arrays: vec![None; capacity],
+            objects: vec![None; capacity],
             type_ids: vec![0; capacity],
             index: 0,
             capacity,
@@ -61,7 +66,8 @@ impl JsonUnion {
             JsonUnionField::Int(value) => self.ints[self.index] = Some(value),
             JsonUnionField::Float(value) => self.floats[self.index] = Some(value),
             JsonUnionField::Str(value) => self.strings[self.index] = Some(value),
-            JsonUnionField::Json { is_object, nested_json } => self.json[self.index] = Some((is_object, nested_json)),
+            JsonUnionField::Array(value) => self.arrays[self.index] = Some(value),
+            JsonUnionField::Object(value) => self.objects[self.index] = Some(value),
         }
         self.index += 1;
         debug_assert!(self.index <= self.capacity);
@@ -95,23 +101,15 @@ impl FromIterator<Option<JsonUnionField>> for JsonUnion {
 impl TryFrom<JsonUnion> for UnionArray {
     type Error = arrow::error::ArrowError;
 
-    #[allow(clippy::from_iter_instead_of_collect)]
     fn try_from(value: JsonUnion) -> Result<Self, Self::Error> {
-        let struct_arrays: Vec<Arc<dyn Array>> = vec![
-            Arc::new(BooleanArray::from_iter(
-                value.json.iter().map(|v| v.as_ref().map(|(is_object, _)| *is_object)),
-            )),
-            Arc::new(StringArray::from_iter(
-                value.json.into_iter().map(|v| v.map(|(_, nested_json)| nested_json)),
-            )),
-        ];
         let children: Vec<Arc<dyn Array>> = vec![
             Arc::new(BooleanArray::from(value.nulls)),
             Arc::new(BooleanArray::from(value.bools)),
             Arc::new(Int64Array::from(value.ints)),
             Arc::new(Float64Array::from(value.floats)),
             Arc::new(StringArray::from(value.strings)),
-            Arc::new(StructArray::new(nested_json_fields(), struct_arrays, None)),
+            Arc::new(StringArray::from(value.arrays)),
+            Arc::new(StringArray::from(value.objects)),
         ];
         UnionArray::try_new(union_fields(), Buffer::from_vec(value.type_ids).into(), None, children)
     }
@@ -124,7 +122,8 @@ pub(crate) enum JsonUnionField {
     Int(i64),
     Float(f64),
     Str(String),
-    Json { is_object: bool, nested_json: String },
+    Array(String),
+    Object(String),
 }
 
 const TYPE_ID_NULL: i8 = 0;
@@ -132,7 +131,8 @@ const TYPE_ID_BOOL: i8 = 1;
 const TYPE_ID_INT: i8 = 2;
 const TYPE_ID_FLOAT: i8 = 3;
 const TYPE_ID_STR: i8 = 4;
-const TYPE_ID_JSON: i8 = 5;
+const TYPE_ID_ARRAY: i8 = 5;
+const TYPE_ID_OBJECT: i8 = 6;
 
 fn union_fields() -> UnionFields {
     static FIELDS: OnceLock<UnionFields> = OnceLock::new();
@@ -144,22 +144,8 @@ fn union_fields() -> UnionFields {
                 (TYPE_ID_INT, Arc::new(Field::new("int", DataType::Int64, false))),
                 (TYPE_ID_FLOAT, Arc::new(Field::new("float", DataType::Float64, false))),
                 (TYPE_ID_STR, Arc::new(Field::new("str", DataType::Utf8, false))),
-                (
-                    TYPE_ID_JSON,
-                    Arc::new(Field::new("json", DataType::Struct(nested_json_fields()), false)),
-                ),
-            ])
-        })
-        .clone()
-}
-
-fn nested_json_fields() -> Fields {
-    static NESTED_JSON_FIELDS: OnceLock<Fields> = OnceLock::new();
-    NESTED_JSON_FIELDS
-        .get_or_init(|| {
-            Fields::from_iter([
-                Field::new("is_object", DataType::Boolean, true),
-                Field::new("nested_json", DataType::Utf8, true),
+                (TYPE_ID_ARRAY, Arc::new(Field::new("array", DataType::Utf8, false))),
+                (TYPE_ID_OBJECT, Arc::new(Field::new("object", DataType::Utf8, false))),
             ])
         })
         .clone()
@@ -173,7 +159,8 @@ impl JsonUnionField {
             Self::Int(_) => TYPE_ID_INT,
             Self::Float(_) => TYPE_ID_FLOAT,
             Self::Str(_) => TYPE_ID_STR,
-            Self::Json { .. } => TYPE_ID_JSON,
+            Self::Array(_) => TYPE_ID_ARRAY,
+            Self::Object(_) => TYPE_ID_OBJECT,
         }
     }
 
@@ -193,8 +180,7 @@ impl From<JsonUnionField> for ScalarValue {
             JsonUnionField::Bool(b) => Self::Boolean(Some(b)),
             JsonUnionField::Int(i) => Self::Int64(Some(i)),
             JsonUnionField::Float(f) => Self::Float64(Some(f)),
-            JsonUnionField::Str(s) => Self::Utf8(Some(s)),
-            JsonUnionField::Json { nested_json, .. } => Self::Utf8(Some(nested_json)),
+            JsonUnionField::Str(s) | JsonUnionField::Array(s) | JsonUnionField::Object(s) => Self::Utf8(Some(s)),
         }
     }
 }

--- a/src/common_union.rs
+++ b/src/common_union.rs
@@ -24,6 +24,22 @@ pub(crate) fn nested_json_array(array: &ArrayRef, object_lookup: bool) -> Option
     union_array.child(type_id).as_any().downcast_ref()
 }
 
+/// Extract a JSON string from a `JsonUnion` scalar
+pub(crate) fn json_from_union_scalar<'a>(
+    type_id_value: &'a Option<(i8, Box<ScalarValue>)>,
+    fields: &UnionFields,
+) -> Option<&'a str> {
+    if let Some((type_id, value)) = type_id_value {
+        // we only want to take teh ScalarValue string if the type_id indicates the value represents nested JSON
+        if fields == &union_fields() && (*type_id == TYPE_ID_ARRAY || *type_id == TYPE_ID_OBJECT) {
+            if let ScalarValue::Utf8(s) = value.as_ref() {
+                return s.as_ref().map(String::as_str);
+            }
+        }
+    }
+    None
+}
+
 #[derive(Debug)]
 pub(crate) struct JsonUnion {
     nulls: Vec<Option<bool>>,

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -93,20 +93,14 @@ fn build_union(jiter: &mut Jiter, peek: Peek) -> Result<JsonUnionField, GetError
             jiter.known_skip(peek)?;
             let array_slice = jiter.slice_to_current(start);
             let array_string = std::str::from_utf8(array_slice)?;
-            Ok(JsonUnionField::Json {
-                is_object: false,
-                nested_json: array_string.to_owned(),
-            })
+            Ok(JsonUnionField::Array(array_string.to_owned()))
         }
         Peek::Object => {
             let start = jiter.current_index();
             jiter.known_skip(peek)?;
             let object_slice = jiter.slice_to_current(start);
             let object_string = std::str::from_utf8(object_slice)?;
-            Ok(JsonUnionField::Json {
-                is_object: true,
-                nested_json: object_string.to_owned(),
-            })
+            Ok(JsonUnionField::Object(object_string.to_owned()))
         }
         _ => match jiter.known_number(peek)? {
             NumberAny::Int(NumberInt::Int(value)) => Ok(JsonUnionField::Int(value)),

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -93,14 +93,20 @@ fn build_union(jiter: &mut Jiter, peek: Peek) -> Result<JsonUnionField, GetError
             jiter.known_skip(peek)?;
             let array_slice = jiter.slice_to_current(start);
             let array_string = std::str::from_utf8(array_slice)?;
-            Ok(JsonUnionField::Array(array_string.to_owned()))
+            Ok(JsonUnionField::Json {
+                is_object: false,
+                nested_json: array_string.to_owned(),
+            })
         }
         Peek::Object => {
             let start = jiter.current_index();
             jiter.known_skip(peek)?;
             let object_slice = jiter.slice_to_current(start);
             let object_string = std::str::from_utf8(object_slice)?;
-            Ok(JsonUnionField::Object(object_string.to_owned()))
+            Ok(JsonUnionField::Json {
+                is_object: true,
+                nested_json: object_string.to_owned(),
+            })
         }
         _ => match jiter.known_number(peek)? {
             NumberAny::Int(NumberInt::Int(value)) => Ok(JsonUnionField::Int(value)),

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -62,17 +62,17 @@ async fn test_json_get_union() {
         .unwrap();
 
     let expected = [
-        "+------------------+---------------------------------------------+",
-        "| name             | json_get(test.json_data,Utf8(\"foo\"))        |",
-        "+------------------+---------------------------------------------+",
-        "| object_foo       | {str=abc}                                   |",
-        "| object_foo_array | {json={is_object: false, nested_json: [1]}} |",
-        "| object_foo_obj   | {json={is_object: true, nested_json: {}}}   |",
-        "| object_foo_null  | {null=true}                                 |",
-        "| object_bar       | {null=}                                     |",
-        "| list_foo         | {null=}                                     |",
-        "| invalid_json     | {null=}                                     |",
-        "+------------------+---------------------------------------------+",
+        "+------------------+--------------------------------------+",
+        "| name             | json_get(test.json_data,Utf8(\"foo\")) |",
+        "+------------------+--------------------------------------+",
+        "| object_foo       | {str=abc}                            |",
+        "| object_foo_array | {array=[1]}                          |",
+        "| object_foo_obj   | {object={}}                          |",
+        "| object_foo_null  | {null=true}                          |",
+        "| object_bar       | {null=}                              |",
+        "| list_foo         | {null=}                              |",
+        "| invalid_json     | {null=}                              |",
+        "+------------------+--------------------------------------+",
     ];
     assert_batches_eq!(expected, &batches);
 }
@@ -547,13 +547,13 @@ async fn test_json_get_union_array() {
 #[tokio::test]
 async fn test_json_get_union_array_skip() {
     let expected = [
-        "+---------------------------------------------+",
-        "| v                                           |",
-        "+---------------------------------------------+",
-        "| {json={is_object: false, nested_json: [0]}} |",
-        "| {null=}                                     |",
-        "| {null=true}                                 |",
-        "+---------------------------------------------+",
+        "+-------------+",
+        "| v           |",
+        "+-------------+",
+        "| {array=[0]} |",
+        "| {null=}     |",
+        "| {null=true} |",
+        "+-------------+",
     ];
 
     let sql = "select json_get(json_get(json_data, str_key1), str_key2) v from more_nested";

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -70,6 +70,44 @@ async fn create_test_table(large_utf8: bool) -> Result<SessionContext> {
     )?;
     ctx.register_batch("other", other_batch)?;
 
+    let more_nested = [
+        (r#" {"foo": {"bar": [0]}} "#, "foo", "bar", 0),
+        (r#" {"foo": {"bar": [1]}} "#, "foo", "spam", 0),
+        (r#" {"foo": {"bar": null}} "#, "foo", "bar", 0),
+    ];
+    let more_nested_batch = RecordBatch::try_new(
+        Arc::new(Schema::new(vec![
+            Field::new("json_data", DataType::Utf8, false),
+            Field::new("str_key1", DataType::Utf8, false),
+            Field::new("str_key2", DataType::Utf8, false),
+            Field::new("int_key", DataType::Int64, false),
+        ])),
+        vec![
+            Arc::new(StringArray::from(
+                more_nested.iter().map(|(json, _, _, _)| *json).collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                more_nested
+                    .iter()
+                    .map(|(_, str_key1, _, _)| *str_key1)
+                    .collect::<Vec<_>>(),
+            )),
+            Arc::new(StringArray::from(
+                more_nested
+                    .iter()
+                    .map(|(_, _, str_key2, _)| *str_key2)
+                    .collect::<Vec<_>>(),
+            )),
+            Arc::new(Int64Array::from(
+                more_nested
+                    .iter()
+                    .map(|(_, _, _, int_key)| *int_key)
+                    .collect::<Vec<_>>(),
+            )),
+        ],
+    )?;
+    ctx.register_batch("more_nested", more_nested_batch)?;
+
     Ok(ctx)
 }
 


### PR DESCRIPTION
This allows queries of the form

```sql
select json_get(json_get(json_data, 'foo'), 0) from test
```

These cases could be simplified, but it'll be much harder/impossible to simplify use of json unions from CTEs or other parts of the query.

## Note

The above query would be much more efficient if written:

```sql
select json_get(json_data, 'foo', 0) from test
```

cc @dmontagu