### PR TITLE
json_find: make implementation much shorter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ datafusion-execution = "39"
 codspeed-criterion-compat = "2.3"
 criterion = "0.5.1"
 datafusion = "39"
+clap = "~4.4" # for testing on MSRV 1.73
 tokio = { version = "1.37", features = ["full"] }
 
 [lints.clippy]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,8 @@ log = "0.4"
 datafusion-execution = "39"
 
 [dev-dependencies]
+codspeed-criterion-compat = "2.3"
+criterion = "0.5.1"
 datafusion = "39"
 tokio = { version = "1.37", features = ["full"] }
 
@@ -33,3 +35,7 @@ print_stdout = "deny"
 pedantic = { level = "deny", priority = -1 }
 missing_errors_doc = "allow"
 cast_possible_truncation = "allow"
+
+[[bench]]
+name = "main"
+harness = false

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,38 @@
+use codspeed_criterion_compat::{criterion_group, criterion_main, Bencher, Criterion};
+
+use datafusion_common::ScalarValue;
+use datafusion_expr::ColumnarValue;
+use datafusion_functions_json::udfs::{json_contains_udf, json_get_str_udf};
+
+fn bench_json_contains(b: &mut Bencher) {
+    let json_contains = json_contains_udf();
+    let args = &[
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+            r#"{"a": {"aa": "x", "ab: "y"}, "b": []}"#.to_string(),
+        ))),
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some("a".to_string()))),
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some("aa".to_string()))),
+    ];
+
+    b.iter(|| json_contains.invoke(args).unwrap());
+}
+
+fn bench_json_get_str(b: &mut Bencher) {
+    let json_get_str = json_get_str_udf();
+    let args = &[
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some(
+            r#"{"a": {"aa": "x", "ab: "y"}, "b": []}"#.to_string(),
+        ))),
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some("a".to_string()))),
+        ColumnarValue::Scalar(ScalarValue::Utf8(Some("aa".to_string()))),
+    ];
+
+    b.iter(|| json_get_str.invoke(args).unwrap());
+}
+fn criterion_benchmark(c: &mut Criterion) {
+    c.bench_function("json_contains", bench_json_contains);
+    c.bench_function("json_get_str", bench_json_get_str);
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/src/common.rs
+++ b/src/common.rs
@@ -181,7 +181,7 @@ pub fn jiter_json_find<'j>(opt_json: Option<&'j str>, path: &[JsonPath]) -> Opti
                     array_item = jiter.array_step().ok()??;
                 }
 
-                peek = array_item
+                peek = array_item;
             }
             _ => {
                 return None;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,17 @@ pub mod functions {
     pub use crate::json_length::json_length;
 }
 
+pub mod udfs {
+    pub use crate::json_contains::json_contains_udf;
+    pub use crate::json_get::json_get_udf;
+    pub use crate::json_get_bool::json_get_bool_udf;
+    pub use crate::json_get_float::json_get_float_udf;
+    pub use crate::json_get_int::json_get_int_udf;
+    pub use crate::json_get_json::json_get_json_udf;
+    pub use crate::json_get_str::json_get_str_udf;
+    pub use crate::json_length::json_length_udf;
+}
+
 /// Register all JSON UDFs
 pub fn register_all(registry: &mut dyn FunctionRegistry) -> Result<()> {
     let functions: Vec<Arc<ScalarUDF>> = vec![


### PR DESCRIPTION
This rewrites `jiter_json_find` to avoid function calls and instead use tight loops to descend the state. Hopefully a win for both simplicity and performance.