### PR TITLE
invoke: allow `LargeUtf8`

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -29,6 +29,7 @@ fn bench_json_get_str(b: &mut Bencher) {
 
     b.iter(|| json_get_str.invoke(args).unwrap());
 }
+
 fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("json_contains", bench_json_contains);
     c.bench_function("json_get_str", bench_json_get_str);

--- a/src/common.rs
+++ b/src/common.rs
@@ -49,8 +49,7 @@ impl<'s> JsonPath<'s> {
         args[1..]
             .iter()
             .map(|arg| match arg {
-                ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => Self::Key(s),
-                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s))) => Self::Key(s),
+                ColumnarValue::Scalar(ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s))) => Self::Key(s),
                 ColumnarValue::Scalar(ScalarValue::UInt64(Some(i))) => (*i).into(),
                 ColumnarValue::Scalar(ScalarValue::Int64(Some(i))) => (*i).into(),
                 _ => Self::None,

--- a/src/common.rs
+++ b/src/common.rs
@@ -93,7 +93,7 @@ pub fn invoke<C: FromIterator<Option<I>> + 'static, I>(
             };
             to_array(result_collect?).map(ColumnarValue::from)
         }
-        ColumnarValue::Scalar(ScalarValue::Utf8(s)) => {
+        ColumnarValue::Scalar(ScalarValue::Utf8(s) | ScalarValue::LargeUtf8(s)) => {
             let path = JsonPath::extract_path(args);
             let v = jiter_find(s.as_ref().map(String::as_str), &path).ok();
             Ok(ColumnarValue::Scalar(to_scalar(v)))

--- a/src/common.rs
+++ b/src/common.rs
@@ -50,6 +50,7 @@ impl<'s> JsonPath<'s> {
             .iter()
             .map(|arg| match arg {
                 ColumnarValue::Scalar(ScalarValue::Utf8(Some(s))) => Self::Key(s),
+                ColumnarValue::Scalar(ScalarValue::LargeUtf8(Some(s))) => Self::Key(s),
                 ColumnarValue::Scalar(ScalarValue::UInt64(Some(i))) => (*i).into(),
                 ColumnarValue::Scalar(ScalarValue::Int64(Some(i))) => (*i).into(),
                 _ => Self::None,


### PR DESCRIPTION
tests seem to cover this case, but it still seems prudent to add to the match for completeness?