### PR TITLE
unnest `json_get` calls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "Apache-2.0"
 keywords = ["datafusion", "JSON", "SQL"]
 categories = ["database-implementations", "parsing"]
 repository = "https://github.com/datafusion-contrib/datafusion-functions-json/"
-rust-version = "1.73.0"
+rust-version = "1.76.0"
 
 [dependencies]
 arrow = "52"
@@ -24,7 +24,7 @@ datafusion-execution = "39"
 codspeed-criterion-compat = "2.3"
 criterion = "0.5.1"
 datafusion = "39"
-clap = "~4.4" # for testing on MSRV 1.73
+clap = "4"
 tokio = { version = "1.37", features = ["full"] }
 
 [lints.clippy]

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -23,8 +23,42 @@ impl FunctionRewrite for JsonFunctionRewriter {
                     }
                 }
             }
+        } else if let Expr::ScalarFunction(func) = &expr {
+            if let Some(new_func) = unnest_json_calls(func) {
+                return Ok(Transformed::yes(Expr::ScalarFunction(new_func)));
+            }
         }
         Ok(Transformed::no(expr))
+    }
+}
+
+// Replace nested JSON functions e.g. `json_get(json_get(col, 'foo'), 'bar')` with `json_get(col, 'foo', 'bar')`
+fn unnest_json_calls(func: &ScalarFunction) -> Option<ScalarFunction> {
+    if !matches!(
+        func.func.name(),
+        "json_get" | "json_get_bool" | "json_get_float" | "json_get_int" | "json_get_json" | "json_get_str"
+    ) {
+        return None;
+    }
+    let mut outer_args_iter = func.args.iter();
+    let first_arg = outer_args_iter.next()?;
+    let Expr::ScalarFunction(inner_func) = first_arg else {
+        return None;
+    };
+    if inner_func.func.name() != "json_get" {
+        return None;
+    }
+
+    let mut args = inner_func.args.clone();
+    args.extend(outer_args_iter.cloned());
+    // See #23, unnest only when all lookup arguments are literals
+    if args.iter().skip(1).all(|arg| matches!(arg, Expr::Literal(_))) {
+        Some(ScalarFunction {
+            func: func.func.clone(),
+            args,
+        })
+    } else {
+        None
     }
 }
 

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -142,3 +142,10 @@ pub async fn display_val(batch: Vec<RecordBatch>) -> (DataType, String) {
     let repr = f.value(0).try_to_string().unwrap();
     (schema_col.data_type().clone(), repr)
 }
+
+pub async fn logical_plan(sql: &str) -> Vec<String> {
+    let batches = run_query(sql).await.unwrap();
+    let plan_col = batches[0].column(1).as_any().downcast_ref::<StringArray>().unwrap();
+    let logical_plan = plan_col.value(0);
+    logical_plan.split('\n').map(|s| s.to_string()).collect()
+}


### PR DESCRIPTION
This takes the good bits from #22.

The idea is that `json_get(json_get(col, 'foo'), 'bar')` gets optimised to `json_get(col, 'foo', 'bar')` so we can have one call into theJSON parsing logic.

But we can't do that where multiple arguments use arrays as lookup conditions due to #23.