### PR TITLE
Make `json_get_int` and `json_get_float` more lax

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use arrow::array::{Array, ArrayRef, Int64Array, LargeStringArray, StringArray, U
 use arrow_schema::DataType;
 use datafusion_common::{exec_err, plan_err, Result as DataFusionResult, ScalarValue};
 use datafusion_expr::ColumnarValue;
-use jiter::{Jiter, JiterError, Peek};
+use jiter::{Jiter, JiterError, JsonError, Peek};
 
 use crate::common_union::{is_json_union, json_from_union_scalar, nested_json_array};
 
@@ -226,6 +226,12 @@ pub struct GetError;
 
 impl From<JiterError> for GetError {
     fn from(_: JiterError) -> Self {
+        GetError
+    }
+}
+
+impl From<JsonError> for GetError {
+    fn from(_: JsonError) -> Self {
         GetError
     }
 }

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -65,7 +65,8 @@ impl ScalarUDFImpl for JsonGetFloat {
 
 fn jiter_json_get_float(json_data: Option<&str>, path: &[JsonPath]) -> Result<f64, GetError> {
     if let Some((mut jiter, peek)) = jiter_json_find(json_data, path) {
-        match peek {
+        let n = match peek {
+            // Peek::String => NumberAny::try_from(jiter.next_bytes()?)?,
             // numbers are represented by everything else in peek, hence doing it this way
             Peek::Null
             | Peek::True
@@ -75,11 +76,12 @@ fn jiter_json_get_float(json_data: Option<&str>, path: &[JsonPath]) -> Result<f6
             | Peek::NaN
             | Peek::String
             | Peek::Array
-            | Peek::Object => get_err!(),
-            _ => match jiter.known_number(peek)? {
-                NumberAny::Float(f) => Ok(f),
-                NumberAny::Int(int) => Ok(int.into()),
-            },
+            | Peek::Object => return get_err!(),
+            _ => jiter.known_number(peek)?,
+        };
+        match n {
+            NumberAny::Float(f) => Ok(f),
+            NumberAny::Int(int) => Ok(int.into()),
         }
     } else {
         get_err!()

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -78,7 +78,7 @@ fn unnest_json_calls(func: &ScalarFunction) -> Option<Transformed<Expr>> {
 fn extract_scalar_function(expr: &Expr) -> Option<&ScalarFunction> {
     match expr {
         Expr::ScalarFunction(func) => Some(func),
-        Expr::Alias(alias) => extract_scalar_function(&*alias.expr),
+        Expr::Alias(alias) => extract_scalar_function(&alias.expr),
         _ => None,
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1131,8 +1131,30 @@ async fn test_long_arrow_cast() {
     assert_batches_eq!(expected, &batches);
 }
 
+#[tokio::test]
 async fn test_arrow_cast_numeric() {
     let sql = r#"select ('{"foo": 420}'->'foo')::numeric = 420"#;
     let batches = run_query(sql).await.unwrap();
     assert_eq!(display_val(batches).await, (DataType::Boolean, "true".to_string()));
 }
+
+#[tokio::test]
+async fn test_json_get_int_string() {
+    let sql = r#"select json_get_int('{"foo": "420"}'->'foo')"#;
+    let batches = run_query(sql).await.unwrap();
+    assert_eq!(display_val(batches).await, (DataType::Int64, "420".to_string()));
+}
+
+// #[tokio::test]
+// async fn test_json_get_float_string() {
+//     let sql = r#"select json_get_float('{"foo": "420.123"}'->'foo')"#;
+//     let batches = run_query(sql).await.unwrap();
+//     assert_eq!(display_val(batches).await, (DataType::Int64, "420.123".to_string()));
+// }
+//
+// #[tokio::test]
+// async fn test_json_get_float_string_2() {
+//     let sql = r#"select json_get_float('{"foo": "420"}'->'foo')"#;
+//     let batches = run_query(sql).await.unwrap();
+//     assert_eq!(display_val(batches).await, (DataType::Int64, "420".to_string()));
+// }


### PR DESCRIPTION
WIP requires https://github.com/pydantic/jiter/pull/128.

The  idea is that since `json_get_int` and `json_get_float` now support parsing strings as well as floats and ints, although looking again at Postgres, I'm not sure this is correct.

Locally I see:

```
postgres@localhost:postgres> select ('{"foo": "123"}'::jsonb->>'foo')::numeric
╒═════════╕
│ numeric │
╞═════════╡
│ 123     │
╘═════════╛
SELECT 1
Time: 0.007s
postgres@localhost:postgres> select ('{"foo": "123"}'::jsonb->'foo')::numeric
cannot cast jsonb string to type numeric
Time: 0.002s
```

In other words `->>` allows casting a string field to an int (since the operator returns a string, the same for `{"foo": "123"}` as `{"foo": 123}`), but `->` returns JSON where casting from a string field to numeric is not supported.

@dmontagu @alexmojaki am I missing something?