### PR TITLE
Don't return dictionary encoded booleans

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
     pass_filenames: false
   - id: clippy
     name: Clippy
-    entry: cargo clippy
+    entry: cargo clippy -- -D warnings
     types: [rust]
     language: system
     pass_filenames: false

--- a/src/json_as_text.rs
+++ b/src/json_as_text.rs
@@ -7,7 +7,7 @@ use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonAsText {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), DataType::Utf8)
+        return_type_check(arg_types, self.name()).map(|()| DataType::Utf8)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_as_text.rs
+++ b/src/json_as_text.rs
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonAsText {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| DataType::Utf8)
+        return_type_check(arg_types, self.name(), DataType::Utf8)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -55,6 +55,7 @@ impl ScalarUDFImpl for JsonAsText {
             jiter_json_as_text,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Utf8,
+            true,
         )
     }
 

--- a/src/json_contains.rs
+++ b/src/json_contains.rs
@@ -48,17 +48,28 @@ impl ScalarUDFImpl for JsonContains {
         if arg_types.len() < 2 {
             plan_err!("The 'json_contains' function requires two or more arguments.")
         } else {
-            scalar_udf_return_type(arg_types, self.name(), DataType::Boolean)
+            scalar_udf_return_type(arg_types, self.name(), DataType::Boolean)?;
+            // we always return a bool to work around https://github.com/apache/datafusion/issues/12380
+            Ok(DataType::Boolean)
         }
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
-        invoke::<BooleanArray, bool>(
+        let r = invoke::<BooleanArray, bool>(
             args,
             jiter_json_contains,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Boolean,
-        )
+        );
+        // work around for https://github.com/apache/datafusion/issues/12380
+        // if this becomes permanent, adjust invoke to not dictionary encode the result in the first place
+        if let Ok(ColumnarValue::Array(a)) = &r {
+            use datafusion::arrow::array::AsArray;
+            if let Some(a) = a.as_any_dictionary_opt() {
+                return Ok(ColumnarValue::Array(a.values().clone()));
+            }
+        }
+        r
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_contains.rs
+++ b/src/json_contains.rs
@@ -48,7 +48,7 @@ impl ScalarUDFImpl for JsonContains {
         if arg_types.len() < 2 {
             plan_err!("The 'json_contains' function requires two or more arguments.")
         } else {
-            return_type_check(arg_types, self.name()).map(|()| DataType::Boolean)
+            return_type_check(arg_types, self.name(), DataType::Boolean).map(|_| DataType::Boolean)
         }
     }
 
@@ -58,6 +58,7 @@ impl ScalarUDFImpl for JsonContains {
             jiter_json_contains,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Boolean,
+            false,
         )
     }
 

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -8,7 +8,7 @@ use datafusion::common::Result as DataFusionResult;
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::{Jiter, NumberAny, NumberInt, Peek};
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 use crate::common_union::{JsonUnion, JsonUnionField};
 
@@ -50,7 +50,7 @@ impl ScalarUDFImpl for JsonGet {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), JsonUnion::data_type())
+        return_type_check(arg_types, self.name()).map(|()| JsonUnion::data_type())
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -50,7 +50,7 @@ impl ScalarUDFImpl for JsonGet {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| JsonUnion::data_type())
+        return_type_check(arg_types, self.name(), JsonUnion::data_type())
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -58,7 +58,7 @@ impl ScalarUDFImpl for JsonGet {
             let array: UnionArray = c.try_into()?;
             Ok(Arc::new(array) as ArrayRef)
         };
-        invoke::<JsonUnion, JsonUnionField>(args, jiter_json_get_union, to_array, JsonUnionField::scalar_value)
+        invoke::<JsonUnion, JsonUnionField>(args, jiter_json_get_union, to_array, JsonUnionField::scalar_value, true)
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_get_bool.rs
+++ b/src/json_get_bool.rs
@@ -7,7 +7,7 @@ use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetBool {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), DataType::Boolean)
+        return_type_check(arg_types, self.name()).map(|()| DataType::Boolean)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_get_bool.rs
+++ b/src/json_get_bool.rs
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetBool {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| DataType::Boolean)
+        return_type_check(arg_types, self.name(), DataType::Boolean)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -55,6 +55,7 @@ impl ScalarUDFImpl for JsonGetBool {
             jiter_json_get_bool,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Boolean,
+            true,
         )
     }
 

--- a/src/json_get_bool.rs
+++ b/src/json_get_bool.rs
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetBool {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name(), DataType::Boolean)
+        return_type_check(arg_types, self.name(), DataType::Boolean).map(|_| DataType::Boolean)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -55,7 +55,7 @@ impl ScalarUDFImpl for JsonGetBool {
             jiter_json_get_bool,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Boolean,
-            true,
+            false,
         )
     }
 

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -7,7 +7,7 @@ use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::{NumberAny, Peek};
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetFloat {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), DataType::Float64)
+        return_type_check(arg_types, self.name()).map(|()| DataType::Float64)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetFloat {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| DataType::Float64)
+        return_type_check(arg_types, self.name(), DataType::Float64)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -55,6 +55,7 @@ impl ScalarUDFImpl for JsonGetFloat {
             jiter_json_get_float,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Float64,
+            true,
         )
     }
 

--- a/src/json_get_int.rs
+++ b/src/json_get_int.rs
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetInt {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| DataType::Int64)
+        return_type_check(arg_types, self.name(), DataType::Int64)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -55,6 +55,7 @@ impl ScalarUDFImpl for JsonGetInt {
             jiter_json_get_int,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Int64,
+            true,
         )
     }
 

--- a/src/json_get_int.rs
+++ b/src/json_get_int.rs
@@ -7,7 +7,7 @@ use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::{NumberInt, Peek};
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetInt {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), DataType::Int64)
+        return_type_check(arg_types, self.name()).map(|()| DataType::Int64)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -45,7 +45,7 @@ impl ScalarUDFImpl for JsonGetJson {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| DataType::Utf8)
+        return_type_check(arg_types, self.name(), DataType::Utf8)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -54,6 +54,7 @@ impl ScalarUDFImpl for JsonGetJson {
             jiter_json_get_json,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Utf8,
+            true,
         )
     }
 

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -6,7 +6,7 @@ use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -45,7 +45,7 @@ impl ScalarUDFImpl for JsonGetJson {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), DataType::Utf8)
+        return_type_check(arg_types, self.name()).map(|()| DataType::Utf8)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_get_str.rs
+++ b/src/json_get_str.rs
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetStr {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| DataType::Utf8)
+        return_type_check(arg_types, self.name(), DataType::Utf8)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -55,6 +55,7 @@ impl ScalarUDFImpl for JsonGetStr {
             jiter_json_get_str,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::Utf8,
+            true,
         )
     }
 

--- a/src/json_get_str.rs
+++ b/src/json_get_str.rs
@@ -7,7 +7,7 @@ use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonGetStr {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), DataType::Utf8)
+        return_type_check(arg_types, self.name()).map(|()| DataType::Utf8)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_length.rs
+++ b/src/json_length.rs
@@ -7,7 +7,7 @@ use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, scalar_udf_return_type, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonLength {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        scalar_udf_return_type(arg_types, self.name(), DataType::UInt64)
+        return_type_check(arg_types, self.name()).map(|()| DataType::UInt64)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {

--- a/src/json_length.rs
+++ b/src/json_length.rs
@@ -46,7 +46,7 @@ impl ScalarUDFImpl for JsonLength {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(arg_types, self.name()).map(|()| DataType::UInt64)
+        return_type_check(arg_types, self.name(), DataType::UInt64)
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
@@ -55,6 +55,7 @@ impl ScalarUDFImpl for JsonLength {
             jiter_json_length,
             |c| Ok(Arc::new(c) as ArrayRef),
             ScalarValue::UInt64,
+            true,
         )
     }
 

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -78,7 +78,7 @@ fn unnest_json_calls(func: &ScalarFunction) -> Option<Transformed<Expr>> {
 fn extract_scalar_function(expr: &Expr) -> Option<&ScalarFunction> {
     match expr {
         Expr::ScalarFunction(func) => Some(func),
-        Expr::Alias(alias) => extract_scalar_function(&*alias.expr),
+        Expr::Alias(alias) => extract_scalar_function(&alias.expr),
         _ => None,
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,10 +1,14 @@
-use datafusion::arrow::datatypes::DataType;
+use std::sync::Arc;
+
+use datafusion::arrow::array::{ArrayRef, RecordBatch};
+use datafusion::arrow::datatypes::{Field, Int8Type, Schema};
+use datafusion::arrow::{array::StringDictionaryBuilder, datatypes::DataType};
 use datafusion::assert_batches_eq;
 use datafusion::common::ScalarValue;
 use datafusion::logical_expr::ColumnarValue;
-
+use datafusion::prelude::SessionContext;
 use datafusion_functions_json::udfs::json_get_str_udf;
-use utils::{display_val, logical_plan, run_query, run_query_large, run_query_params};
+use utils::{create_context, display_val, logical_plan, run_query, run_query_large, run_query_params};
 
 mod utils;
 
@@ -197,11 +201,11 @@ async fn test_json_get_no_path() {
     let batches = run_query(r#"select json_get('"foo"')::string"#).await.unwrap();
     assert_eq!(display_val(batches).await, (DataType::Utf8, "foo".to_string()));
 
-    let batches = run_query(r#"select json_get('123')::int"#).await.unwrap();
+    let batches = run_query(r"select json_get('123')::int").await.unwrap();
     assert_eq!(display_val(batches).await, (DataType::Int64, "123".to_string()));
 
-    let batches = run_query(r#"select json_get('true')::int"#).await.unwrap();
-    assert_eq!(display_val(batches).await, (DataType::Int64, "".to_string()));
+    let batches = run_query(r"select json_get('true')::int").await.unwrap();
+    assert_eq!(display_val(batches).await, (DataType::Int64, String::new()));
 }
 
 #[tokio::test]
@@ -350,7 +354,7 @@ async fn test_json_length_object() {
     let batches = run_query(sql).await.unwrap();
     assert_eq!(display_val(batches).await, (DataType::UInt64, "3".to_string()));
 
-    let sql = r#"select json_length('{}')"#;
+    let sql = r"select json_length('{}')";
     let batches = run_query(sql).await.unwrap();
     assert_eq!(display_val(batches).await, (DataType::UInt64, "0".to_string()));
 }
@@ -359,7 +363,7 @@ async fn test_json_length_object() {
 async fn test_json_length_string() {
     let sql = r#"select json_length('"foobar"')"#;
     let batches = run_query(sql).await.unwrap();
-    assert_eq!(display_val(batches).await, (DataType::UInt64, "".to_string()));
+    assert_eq!(display_val(batches).await, (DataType::UInt64, String::new()));
 }
 
 #[tokio::test]
@@ -370,7 +374,7 @@ async fn test_json_length_object_nested() {
 
     let sql = r#"select json_length('{"a": 1, "b": 2, "c": []}', 'b')"#;
     let batches = run_query(sql).await.unwrap();
-    assert_eq!(display_val(batches).await, (DataType::UInt64, "".to_string()));
+    assert_eq!(display_val(batches).await, (DataType::UInt64, String::new()));
 }
 
 #[tokio::test]
@@ -455,7 +459,7 @@ async fn test_json_contains_large_both_params() {
 
 #[tokio::test]
 async fn test_json_length_vec() {
-    let sql = r#"select name, json_len(json_data) as len from test"#;
+    let sql = r"select name, json_len(json_data) as len from test";
     let batches = run_query(sql).await.unwrap();
 
     let expected = [
@@ -479,7 +483,7 @@ async fn test_json_length_vec() {
 
 #[tokio::test]
 async fn test_no_args() {
-    let err = run_query(r#"select json_len()"#).await.unwrap_err();
+    let err = run_query(r"select json_len()").await.unwrap_err();
     assert!(err
         .to_string()
         .contains("No function matches the given name and argument types 'json_length()'."));
@@ -562,10 +566,10 @@ async fn test_json_get_nested_collapsed() {
 #[tokio::test]
 async fn test_json_get_cte() {
     // avoid auto-un-nesting with a CTE
-    let sql = r#"
+    let sql = r"
         with t as (select name, json_get(json_data, 'foo') j from test)
         select name, json_get(j, 0) v from t
-    "#;
+    ";
     let expected = [
         "+------------------+---------+",
         "| name             | v       |",
@@ -587,11 +591,11 @@ async fn test_json_get_cte() {
 #[tokio::test]
 async fn test_plan_json_get_cte() {
     // avoid auto-unnesting with a CTE
-    let sql = r#"
+    let sql = r"
         explain
         with t as (select name, json_get(json_data, 'foo') j from test)
         select name, json_get(j, 0) v from t
-    "#;
+    ";
     let expected = [
         "Projection: t.name, json_get(t.j, Int64(0)) AS v",
         "  SubqueryAlias: t",
@@ -751,7 +755,7 @@ async fn test_arrow() {
 
 #[tokio::test]
 async fn test_plan_arrow() {
-    let lines = logical_plan(r#"explain select json_data->'foo' from test"#).await;
+    let lines = logical_plan(r"explain select json_data->'foo' from test").await;
 
     let expected = [
         "Projection: json_get(test.json_data, Utf8(\"foo\")) AS test.json_data -> Utf8(\"foo\")",
@@ -783,7 +787,7 @@ async fn test_long_arrow() {
 
 #[tokio::test]
 async fn test_plan_long_arrow() {
-    let lines = logical_plan(r#"explain select json_data->>'foo' from test"#).await;
+    let lines = logical_plan(r"explain select json_data->>'foo' from test").await;
 
     let expected = [
         "Projection: json_as_text(test.json_data, Utf8(\"foo\")) AS test.json_data ->> Utf8(\"foo\")",
@@ -834,7 +838,7 @@ async fn test_arrow_cast_int() {
 
 #[tokio::test]
 async fn test_plan_arrow_cast_int() {
-    let lines = logical_plan(r#"explain select (json_data->'foo')::int from test"#).await;
+    let lines = logical_plan(r"explain select (json_data->'foo')::int from test").await;
 
     let expected = [
         "Projection: json_get_int(test.json_data, Utf8(\"foo\")) AS test.json_data -> Utf8(\"foo\")",
@@ -866,7 +870,7 @@ async fn test_arrow_double_nested() {
 
 #[tokio::test]
 async fn test_plan_arrow_double_nested() {
-    let lines = logical_plan(r#"explain select json_data->'foo'->0 from test"#).await;
+    let lines = logical_plan(r"explain select json_data->'foo'->0 from test").await;
 
     let expected = [
         "Projection: json_get(test.json_data, Utf8(\"foo\"), Int64(0)) AS test.json_data -> Utf8(\"foo\") -> Int64(0)",
@@ -900,7 +904,7 @@ async fn test_arrow_double_nested_cast() {
 
 #[tokio::test]
 async fn test_plan_arrow_double_nested_cast() {
-    let lines = logical_plan(r#"explain select (json_data->'foo'->0)::int from test"#).await;
+    let lines = logical_plan(r"explain select (json_data->'foo'->0)::int from test").await;
 
     let expected = [
         "Projection: json_get_int(test.json_data, Utf8(\"foo\"), Int64(0)) AS test.json_data -> Utf8(\"foo\") -> Int64(0)",
@@ -948,7 +952,7 @@ async fn test_arrow_nested_double_columns() {
 async fn test_lexical_precedence_wrong() {
     let sql = r#"select '{"a": "b"}'->>'a'='b' as v"#;
     let err = run_query(sql).await.unwrap_err();
-    assert_eq!(err.to_string(), "Error during planning: Unexpected argument type to 'json_as_text' at position 2, expected string or int, got Boolean.")
+    assert_eq!(err.to_string(), "Error during planning: Unexpected argument type to 'json_as_text' at position 2, expected string or int, got Boolean.");
 }
 
 #[tokio::test]
@@ -1259,5 +1263,83 @@ async fn test_dict_get_int() {
     ];
 
     let batches = run_query(sql).await.unwrap();
+    assert_batches_eq!(expected, &batches);
+}
+
+async fn build_dict_schema() -> SessionContext {
+    let mut builder = StringDictionaryBuilder::<Int8Type>::new();
+    builder.append(r#"{"foo": "bar"}"#).unwrap();
+    builder.append(r#"{"baz": "fizz"}"#).unwrap();
+    builder.append("nah").unwrap();
+    builder.append(r#"{"baz": "abcd"}"#).unwrap();
+    builder.append_null();
+    builder.append(r#"{"baz": "fizz"}"#).unwrap();
+    builder.append(r#"{"baz": "fizz"}"#).unwrap();
+    builder.append(r#"{"baz": "fizz"}"#).unwrap();
+    builder.append(r#"{"baz": "fizz"}"#).unwrap();
+    builder.append_null();
+
+    let dict = builder.finish();
+    let array = Arc::new(dict) as ArrayRef;
+
+    let schema = Arc::new(Schema::new(vec![Field::new(
+        "x",
+        DataType::Dictionary(Box::new(DataType::Int8), Box::new(DataType::Utf8)),
+        true,
+    )]));
+
+    let data = RecordBatch::try_new(schema.clone(), vec![array]).unwrap();
+
+    let ctx = create_context().await.unwrap();
+    ctx.register_batch("data", data).unwrap();
+    ctx
+}
+
+#[tokio::test]
+async fn test_dict_filter() {
+    let ctx = build_dict_schema().await;
+
+    let sql = "select json_get(x, 'baz') v from data";
+    let expected = [
+        "+------------+",
+        "| v          |",
+        "+------------+",
+        "| {null=}    |",
+        "| {str=fizz} |",
+        "| {null=}    |",
+        "| {str=abcd} |",
+        "| {null=}    |",
+        "| {str=fizz} |",
+        "| {str=fizz} |",
+        "| {str=fizz} |",
+        "| {str=fizz} |",
+        "| {null=}    |",
+        "+------------+",
+    ];
+
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+
+    assert_batches_eq!(expected, &batches);
+}
+
+#[tokio::test]
+async fn test_dict_filter_is_not_null() {
+    let ctx = build_dict_schema().await;
+    let sql = "select x from data where json_get(x, 'baz') is not null";
+    let expected = [
+        "+-----------------+",
+        "| x               |",
+        "+-----------------+",
+        "| {\"baz\": \"fizz\"} |",
+        "| {\"baz\": \"abcd\"} |",
+        "| {\"baz\": \"fizz\"} |",
+        "| {\"baz\": \"fizz\"} |",
+        "| {\"baz\": \"fizz\"} |",
+        "| {\"baz\": \"fizz\"} |",
+        "+-----------------+",
+    ];
+
+    let batches = ctx.sql(sql).await.unwrap().collect().await.unwrap();
+
     assert_batches_eq!(expected, &batches);
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1149,6 +1149,7 @@ async fn test_dict_haystack() {
         "| {object={\"bar\": [0]}} |",
         "| {null=}               |",
         "| {null=}               |",
+        "| {null=}               |",
         "+-----------------------+",
     ];
 
@@ -1166,6 +1167,7 @@ async fn test_dict_haystack_needle() {
         "| {array=[0]} |",
         "| {null=}     |",
         "| {null=}     |",
+        "| {null=}     |",
         "+-------------+",
     ];
 
@@ -1176,7 +1178,7 @@ async fn test_dict_haystack_needle() {
 #[tokio::test]
 async fn test_dict_length() {
     let sql = "select json_length(json_data) v from dicts";
-    let expected = ["+---+", "| v |", "+---+", "| 1 |", "| 1 |", "| 2 |", "+---+"];
+    let expected = ["+---+", "| v |", "+---+", "| 1 |", "| 1 |", "| 2 |", "| 2 |", "+---+"];
 
     let batches = run_query(sql).await.unwrap();
     assert_batches_eq!(expected, &batches);
@@ -1192,7 +1194,24 @@ async fn test_dict_contains() {
         "| false |",
         "| false |",
         "| true  |",
+        "| true  |",
         "+-------+",
+    ];
+
+    let batches = run_query(sql).await.unwrap();
+    assert_batches_eq!(expected, &batches);
+}
+
+#[tokio::test]
+async fn test_dict_contains_where() {
+    let sql = "select str_key2 from dicts where json_contains(json_data, str_key2)";
+    let expected = [
+        "+----------+",
+        "| str_key2 |",
+        "+----------+",
+        "| spam     |",
+        "| snap     |",
+        "+----------+",
     ];
 
     let batches = run_query(sql).await.unwrap();
@@ -1202,7 +1221,7 @@ async fn test_dict_contains() {
 #[tokio::test]
 async fn test_dict_get_int() {
     let sql = "select json_get_int(json_data, str_key2) v from dicts";
-    let expected = ["+---+", "| v |", "+---+", "|   |", "|   |", "| 1 |", "+---+"];
+    let expected = ["+---+", "| v |", "+---+", "|   |", "|   |", "| 1 |", "| 2 |", "+---+"];
 
     let batches = run_query(sql).await.unwrap();
     assert_batches_eq!(expected, &batches);

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1324,6 +1324,10 @@ async fn build_dict_schema() -> SessionContext {
     builder.append_null();
 
     let dict = builder.finish();
+
+    assert_eq!(dict.len(), 10);
+    assert_eq!(dict.values().len(), 4);
+
     let array = Arc::new(dict) as ArrayRef;
 
     let schema = Arc::new(Schema::new(vec![Field::new(
@@ -1409,7 +1413,7 @@ async fn test_dict_filter_contains() {
 
     assert_batches_eq!(expected, &batches);
 
-    // try with a boolean or as well
+    // test with a boolean OR as well
     let batches = ctx
         .sql(&format!("{sql} or false"))
         .await

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1158,6 +1158,21 @@ async fn test_dict_haystack() {
 }
 
 #[tokio::test]
+async fn test_dict_haystack_filter() {
+    let sql = "select json_data v from dicts where json_get(json_data, 'foo') is not null";
+    let expected = [
+        "+-------------------------+",
+        "| v                       |",
+        "+-------------------------+",
+        "|  {\"foo\": {\"bar\": [0]}}  |",
+        "+-------------------------+",
+    ];
+
+    let batches = run_query(sql).await.unwrap();
+    assert_batches_eq!(expected, &batches);
+}
+
+#[tokio::test]
 async fn test_dict_haystack_needle() {
     let sql = "select json_get(json_get(json_data, str_key1), str_key2) v from dicts";
     let expected = [
@@ -1178,7 +1193,17 @@ async fn test_dict_haystack_needle() {
 #[tokio::test]
 async fn test_dict_length() {
     let sql = "select json_length(json_data) v from dicts";
-    let expected = ["+---+", "| v |", "+---+", "| 1 |", "| 1 |", "| 2 |", "| 2 |", "+---+"];
+    #[rustfmt::skip]
+    let expected = [
+        "+---+",
+        "| v |",
+        "+---+",
+        "| 1 |",
+        "| 1 |",
+        "| 2 |",
+        "| 2 |",
+        "+---+",
+    ];
 
     let batches = run_query(sql).await.unwrap();
     assert_batches_eq!(expected, &batches);
@@ -1221,7 +1246,17 @@ async fn test_dict_contains_where() {
 #[tokio::test]
 async fn test_dict_get_int() {
     let sql = "select json_get_int(json_data, str_key2) v from dicts";
-    let expected = ["+---+", "| v |", "+---+", "|   |", "|   |", "| 1 |", "| 2 |", "+---+"];
+    #[rustfmt::skip]
+    let expected = [
+        "+---+",
+        "| v |",
+        "+---+",
+        "|   |",
+        "|   |",
+        "| 1 |",
+        "| 2 |",
+        "+---+",
+    ];
 
     let batches = run_query(sql).await.unwrap();
     assert_batches_eq!(expected, &batches);

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -13,10 +13,15 @@ use datafusion::execution::context::SessionContext;
 use datafusion::prelude::SessionConfig;
 use datafusion_functions_json::register_all;
 
-async fn create_test_table(large_utf8: bool) -> Result<SessionContext> {
+pub async fn create_context() -> Result<SessionContext> {
     let config = SessionConfig::new().set_str("datafusion.sql_parser.dialect", "postgres");
     let mut ctx = SessionContext::new_with_config(config);
     register_all(&mut ctx)?;
+    Ok(ctx)
+}
+
+async fn create_test_table(large_utf8: bool) -> Result<SessionContext> {
+    let ctx = create_context().await?;
 
     let test_data = [
         ("object_foo", r#" {"foo": "abc"} "#),
@@ -214,5 +219,5 @@ pub async fn logical_plan(sql: &str) -> Vec<String> {
     let batches = run_query(sql).await.unwrap();
     let plan_col = batches[0].column(1).as_any().downcast_ref::<StringArray>().unwrap();
     let logical_plan = plan_col.value(0);
-    logical_plan.split('\n').map(|s| s.to_string()).collect()
+    logical_plan.split('\n').map(ToString::to_string).collect()
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -115,6 +115,7 @@ async fn create_test_table(large_utf8: bool) -> Result<SessionContext> {
         (r#" {"foo": {"bar": [0]}} "#, "foo", "bar", 0),
         (r#" {"bar": "snap"} "#, "foo", "spam", 0),
         (r#" {"spam": 1, "snap": 2} "#, "foo", "spam", 0),
+        (r#" {"spam": 1, "snap": 2} "#, "foo", "snap", 0),
     ];
     let dict_batch = RecordBatch::try_new(
         Arc::new(Schema::new(vec![


### PR DESCRIPTION
Required by https://github.com/apache/datafusion/issues/12380 and also https://github.com/apache/datafusion/issues/12511.

But it's probably more efficient to operate on an array of bools than a dictionary anyway.