### PR TITLE
set keys to null where applicable in dictionary-encoded results

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -345,8 +345,11 @@ impl From<Utf8Error> for GetError {
 
 /// Set keys to null where the union member is null.
 ///
-/// This is a workaround to https://github.com/apache/arrow-rs/issues/6017#issuecomment-2352756753
+/// This is a workaround to <https://github.com/apache/arrow-rs/issues/6017#issuecomment-2352756753>
 /// - i.e. that dictionary null is most reliably done if the keys are null.
+///
+/// That said, doing this might also be an optimization for cases like null-checking without needing
+/// to check the value union array.
 fn mask_dictionary_keys<K: ArrowPrimitiveType>(keys: &PrimitiveArray<K>, type_ids: &[i8]) -> PrimitiveArray<K> {
     let mut null_mask = vec![true; keys.len()];
     for (i, k) in keys.iter().enumerate() {

--- a/src/common_union.rs
+++ b/src/common_union.rs
@@ -141,7 +141,7 @@ pub(crate) enum JsonUnionField {
     Object(String),
 }
 
-const TYPE_ID_NULL: i8 = 0;
+pub(crate) const TYPE_ID_NULL: i8 = 0;
 const TYPE_ID_BOOL: i8 = 1;
 const TYPE_ID_INT: i8 = 2;
 const TYPE_ID_FLOAT: i8 = 3;

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -78,7 +78,7 @@ fn unnest_json_calls(func: &ScalarFunction) -> Option<Transformed<Expr>> {
 fn extract_scalar_function(expr: &Expr) -> Option<&ScalarFunction> {
     match expr {
         Expr::ScalarFunction(func) => Some(func),
-        Expr::Alias(alias) => extract_scalar_function(&*alias.expr),
+        Expr::Alias(alias) => extract_scalar_function(&alias.expr),
         _ => None,
     }
 }


### PR DESCRIPTION
This is a workaround for https://github.com/apache/arrow-rs/issues/6017#issuecomment-2352756753

The idea is that for dict-encoded data, the keys can be null which avoids the need to look into the union values at all for nullability.  This should also happen to be more efficient than relying on the above linked issue to be fixed.