### PR TITLE
Upgrade DataFusion to 43

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/datafusion-contrib/datafusion-functions-json/"
 rust-version = "1.79.0"
 
 [dependencies]
-datafusion = "42"
+datafusion = "43"
 jiter = "0.5"
 paste = "1"
 log = "0.4"


### PR DESCRIPTION
Upgrades to the latest DataFusion version, 43. No other changes were needed to upgrade.