### PR TITLE
cast dictionaries to i64 key type to avoid generic explosion

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -432,7 +432,7 @@ fn is_object_lookup_array(data_type: &DataType) -> bool {
 
 /// Cast an array to a dictionary with i64 indices.
 ///
-/// According to https://arrow.apache.org/docs/format/Columnar.html#dictionary-encoded-layout the
+/// According to <https://arrow.apache.org/docs/format/Columnar.html#dictionary-encoded-layout> the
 /// recommendation is to avoid unsigned indices due to technologies like the JVM making it harder to
 /// support unsigned integers.
 ///
@@ -445,7 +445,8 @@ fn cast_to_large_dictionary(dict_array: &dyn AnyDictionaryArray) -> DataFusionRe
 /// Wrap an array as a dictionary with i64 indices.
 fn wrap_as_large_dictionary(original: &dyn AnyDictionaryArray, new_values: ArrayRef) -> DictionaryArray<Int64Type> {
     assert_eq!(original.keys().len(), new_values.len());
-    let mut keys = PrimitiveArray::from_iter_values(0i64..original.keys().len() as i64);
+    let mut keys =
+        PrimitiveArray::from_iter_values(0i64..original.keys().len().try_into().expect("keys out of i64 range"));
     if is_json_union(new_values.data_type()) {
         // JSON union: post-process the array to set keys to null where the union member is null
         let type_ids = new_values.as_union().type_ids();


### PR DESCRIPTION
This PR changes dictionary handling to eagerly upcast the keys to `i64` size.

This allows us to avoid changing any logic but strip a layer of generics away, namely the possible dictionary keys. This results in a ~20x reduction in code size as measured by `cargo llvm-lines`:

before

```
Lines                  Copies                Function name
  -----                  ------                -------------
  6187111                209087                (TOTAL)
   657720 (10.6%, 10.6%)  12600 (6.0%,  6.0%)  datafusion_functions_json::common::zip_apply::inner::{{closure}}
   598662 (9.7%, 20.3%)    3789 (1.8%,  7.8%)  <arrow_array::array::primitive_array::PrimitiveArray<T> as core::iter::traits::collect::FromIterator<Ptr>>::from_iter
   552270 (8.9%, 29.2%)     280 (0.1%,  8.0%)  datafusion_functions_json::common::zip_apply
```

after

```
Lines                 Copies              Function name
  -----                 ------              -------------
  305725                9773                (TOTAL)
   34870 (11.4%, 11.4%)   60 (0.6%,  0.6%)  datafusion_functions_json::common::zip_apply
   25200 (8.2%, 19.6%)   480 (4.9%,  5.5%)  datafusion_functions_json::common::zip_apply::inner::{{closure}}
   24174 (7.9%, 27.6%)   153 (1.6%,  7.1%)  <arrow_array::array::primitive_array::PrimitiveArray<T> as core::iter::traits::collect::FromIterator<Ptr>>::from_iter
```