### PR TITLE
replace `FromIterator` with builder trait

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -294,7 +294,7 @@ fn invoke_array_scalars<R: InvokeResult>(
             if let Some(string_array) = nested_json_array(json_array, is_object_lookup(path)) {
                 inner::<R>(string_array, path, jiter_find)
             } else {
-                return exec_err!("unexpected json array type {:?}", other);
+                exec_err!("unexpected json array type {:?}", other)
             }
         }
     }
@@ -421,7 +421,7 @@ fn zip_apply<'a, R: InvokeResult>(
         DataType::Int64 => inner::<_, R>(json_array, path_array.as_primitive::<Int64Type>(), jiter_find),
         DataType::UInt64 => inner::<_, R>(json_array, path_array.as_primitive::<UInt64Type>(), jiter_find),
         other => {
-            return exec_err!(
+            exec_err!(
                 "unexpected second argument type, expected string or int array, got {:?}",
                 other
             )

--- a/src/common.rs
+++ b/src/common.rs
@@ -43,7 +43,7 @@ pub fn return_type_check(args: &[DataType], fn_name: &str, value_type: DataType)
             )
         }
     })?;
-    if first_dict_key_type.is_some() {
+    if first_dict_key_type.is_some() && !value_type.is_primitive() {
         Ok(DataType::Dictionary(Box::new(DataType::Int64), Box::new(value_type)))
     } else {
         Ok(value_type)

--- a/src/common.rs
+++ b/src/common.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use datafusion::arrow::array::{
     downcast_array, AnyDictionaryArray, Array, ArrayAccessor, ArrayRef, AsArray, DictionaryArray, LargeStringArray,
-    PrimitiveArray, StringArray, StringViewArray,
+    PrimitiveArray, RunArray, StringArray, StringViewArray,
 };
 use datafusion::arrow::compute::kernels::cast;
 use datafusion::arrow::compute::take;
@@ -140,11 +140,21 @@ impl<'s> JsonPathArgs<'s> {
     }
 }
 
-pub fn invoke<C: FromIterator<Option<I>> + 'static, I>(
+pub trait InvokeResult {
+    type Item;
+    type Builder;
+
+    fn builder(capacity: usize) -> Self::Builder;
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>);
+    fn finish(builder: Self::Builder) -> DataFusionResult<ArrayRef>;
+
+    /// Convert a single value to a scalar
+    fn scalar(value: Option<Self::Item>) -> ScalarValue;
+}
+
+pub fn invoke<R: InvokeResult>(
     args: &[ColumnarValue],
-    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<I, GetError>,
-    to_array: impl Fn(C) -> DataFusionResult<ArrayRef>,
-    to_scalar: impl Fn(Option<I>) -> ScalarValue,
+    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<R::Item, GetError>,
     return_dict: bool,
 ) -> DataFusionResult<ColumnarValue> {
     let Some((json_arg, path_args)) = args.split_first() else {
@@ -154,35 +164,33 @@ pub fn invoke<C: FromIterator<Option<I>> + 'static, I>(
     let path = JsonPathArgs::extract_path(path_args)?;
     match (json_arg, path) {
         (ColumnarValue::Array(json_array), JsonPathArgs::Array(path_array)) => {
-            invoke_array_array(json_array, path_array, to_array, jiter_find, return_dict).map(ColumnarValue::Array)
+            invoke_array_array::<R>(json_array, path_array, jiter_find, return_dict).map(ColumnarValue::Array)
         }
         (ColumnarValue::Array(json_array), JsonPathArgs::Scalars(path)) => {
-            invoke_array_scalars(json_array, &path, to_array, jiter_find, return_dict).map(ColumnarValue::Array)
+            invoke_array_scalars::<R>(json_array, &path, jiter_find, return_dict).map(ColumnarValue::Array)
         }
         (ColumnarValue::Scalar(s), JsonPathArgs::Array(path_array)) => {
-            invoke_scalar_array(s, path_array, jiter_find, to_array)
+            invoke_scalar_array::<R>(s, path_array, jiter_find)
         }
         (ColumnarValue::Scalar(s), JsonPathArgs::Scalars(path)) => {
-            invoke_scalar_scalars(s, &path, jiter_find, to_scalar)
+            invoke_scalar_scalars(s, &path, jiter_find, R::scalar)
         }
     }
 }
 
-fn invoke_array_array<C: FromIterator<Option<I>> + 'static, I>(
+fn invoke_array_array<R: InvokeResult>(
     json_array: &ArrayRef,
     path_array: &ArrayRef,
-    to_array: impl Fn(C) -> DataFusionResult<ArrayRef>,
-    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<I, GetError>,
+    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<R::Item, GetError>,
     return_dict: bool,
 ) -> DataFusionResult<ArrayRef> {
     match json_array.data_type() {
         // for string dictionaries, cast dictionary keys to larger types to avoid generic explosion
         DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::Utf8 => {
             let json_array = cast_to_large_dictionary(json_array.as_any_dictionary())?;
-            let output = zip_apply(
+            let output = zip_apply::<R>(
                 json_array.downcast_dict::<StringArray>().unwrap(),
                 path_array,
-                to_array,
                 jiter_find,
             )?;
             if return_dict {
@@ -194,10 +202,9 @@ fn invoke_array_array<C: FromIterator<Option<I>> + 'static, I>(
         }
         DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::LargeUtf8 => {
             let json_array = cast_to_large_dictionary(json_array.as_any_dictionary())?;
-            let output = zip_apply(
+            let output = zip_apply::<R>(
                 json_array.downcast_dict::<LargeStringArray>().unwrap(),
                 path_array,
-                to_array,
                 jiter_find,
             )?;
             if return_dict {
@@ -215,10 +222,9 @@ fn invoke_array_array<C: FromIterator<Option<I>> + 'static, I>(
                 json_array.as_any_dictionary().values(),
                 is_object_lookup_array(path_array.data_type()),
             ) {
-                invoke_array_array(
+                invoke_array_array::<R>(
                     &(Arc::new(json_array.as_any_dictionary().with_values(child_array.clone())) as _),
                     path_array,
-                    to_array,
                     jiter_find,
                     return_dict,
                 )
@@ -226,12 +232,12 @@ fn invoke_array_array<C: FromIterator<Option<I>> + 'static, I>(
                 exec_err!("unexpected json array type {:?}", other_dict_type)
             }
         }
-        DataType::Utf8 => zip_apply(json_array.as_string::<i32>().iter(), path_array, to_array, jiter_find),
-        DataType::LargeUtf8 => zip_apply(json_array.as_string::<i64>().iter(), path_array, to_array, jiter_find),
-        DataType::Utf8View => zip_apply(json_array.as_string_view().iter(), path_array, to_array, jiter_find),
+        DataType::Utf8 => zip_apply::<R>(json_array.as_string::<i32>(), path_array, jiter_find),
+        DataType::LargeUtf8 => zip_apply::<R>(json_array.as_string::<i64>(), path_array, jiter_find),
+        DataType::Utf8View => zip_apply::<R>(json_array.as_string_view(), path_array, jiter_find),
         other => {
             if let Some(string_array) = nested_json_array(json_array, is_object_lookup_array(path_array.data_type())) {
-                zip_apply(string_array.iter(), path_array, to_array, jiter_find)
+                zip_apply::<R>(string_array, path_array, jiter_find)
             } else {
                 exec_err!("unexpected json array type {:?}", other)
             }
@@ -239,28 +245,35 @@ fn invoke_array_array<C: FromIterator<Option<I>> + 'static, I>(
     }
 }
 
-fn invoke_array_scalars<C: FromIterator<Option<I>>, I>(
+fn invoke_array_scalars<R: InvokeResult>(
     json_array: &ArrayRef,
     path: &[JsonPath],
-    to_array: impl Fn(C) -> DataFusionResult<ArrayRef>,
-    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<I, GetError>,
+    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<R::Item, GetError>,
     return_dict: bool,
 ) -> DataFusionResult<ArrayRef> {
-    fn inner<'j, C: FromIterator<Option<I>>, I>(
-        json_iter: impl IntoIterator<Item = Option<&'j str>>,
+    #[allow(clippy::needless_pass_by_value)] // ArrayAccessor is implemented on references
+    fn inner<'j, R: InvokeResult>(
+        json_array: impl ArrayAccessor<Item = &'j str>,
         path: &[JsonPath],
-        jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<I, GetError>,
-    ) -> C {
-        json_iter
-            .into_iter()
-            .map(|opt_json| jiter_find(opt_json, path).ok())
-            .collect::<C>()
+        jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<R::Item, GetError>,
+    ) -> DataFusionResult<ArrayRef> {
+        let mut builder = R::builder(json_array.len());
+        for i in 0..json_array.len() {
+            let opt_json = if json_array.is_null(i) {
+                None
+            } else {
+                Some(json_array.value(i))
+            };
+            let opt_value = jiter_find(opt_json, path).ok();
+            R::append_value(&mut builder, opt_value);
+        }
+        R::finish(builder)
     }
 
-    let c = match json_array.data_type() {
+    match json_array.data_type() {
         DataType::Dictionary(_, _) => {
             let json_array = json_array.as_any_dictionary();
-            let values = invoke_array_scalars(json_array.values(), path, to_array, jiter_find, false)?;
+            let values = invoke_array_scalars::<R>(json_array.values(), path, jiter_find, false)?;
             return if return_dict {
                 // make the keys into i64 to avoid generic bloat here
                 let mut keys: PrimitiveArray<Int64Type> = downcast_array(&cast(json_array.keys(), &DataType::Int64)?);
@@ -275,33 +288,38 @@ fn invoke_array_scalars<C: FromIterator<Option<I>>, I>(
                 Ok(take(&values, json_array.keys(), None)?)
             };
         }
-        DataType::Utf8 => inner(json_array.as_string::<i32>(), path, jiter_find),
-        DataType::LargeUtf8 => inner(json_array.as_string::<i64>(), path, jiter_find),
-        DataType::Utf8View => inner(json_array.as_string_view(), path, jiter_find),
+        DataType::Utf8 => inner::<R>(json_array.as_string::<i32>(), path, jiter_find),
+        DataType::LargeUtf8 => inner::<R>(json_array.as_string::<i64>(), path, jiter_find),
+        DataType::Utf8View => inner::<R>(json_array.as_string_view(), path, jiter_find),
         other => {
             if let Some(string_array) = nested_json_array(json_array, is_object_lookup(path)) {
-                inner(string_array, path, jiter_find)
+                inner::<R>(string_array, path, jiter_find)
             } else {
                 return exec_err!("unexpected json array type {:?}", other);
             }
         }
-    };
-    to_array(c)
+    }
 }
 
-fn invoke_scalar_array<C: FromIterator<Option<I>> + 'static, I>(
+fn invoke_scalar_array<R: InvokeResult>(
     scalar: &ScalarValue,
     path_array: &ArrayRef,
-    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<I, GetError>,
-    to_array: impl Fn(C) -> DataFusionResult<ArrayRef>,
+    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<R::Item, GetError>,
 ) -> DataFusionResult<ColumnarValue> {
     let s = extract_json_scalar(scalar)?;
+    let arr = s.map_or_else(|| StringArray::new_null(1), |s| StringArray::new_scalar(s).into_inner());
+
     // TODO: possible optimization here if path_array is a dictionary; can apply against the
     // dictionary values directly for less work
-    zip_apply(
-        std::iter::repeat(s).take(path_array.len()),
+    zip_apply::<R>(
+        RunArray::try_new(
+            &PrimitiveArray::<Int64Type>::new_scalar(i64::try_from(path_array.len()).expect("len out of i64 range"))
+                .into_inner(),
+            &arr,
+        )?
+        .downcast::<StringArray>()
+        .expect("type known"),
         path_array,
-        to_array,
         jiter_find,
     )
     // FIXME edge cases where scalar is wrapped in a dictionary, should return a dictionary?
@@ -320,37 +338,50 @@ fn invoke_scalar_scalars<I>(
     Ok(ColumnarValue::Scalar(to_scalar(v)))
 }
 
-fn zip_apply<'a, C: FromIterator<Option<I>> + 'static, I>(
-    json_array: impl IntoIterator<Item = Option<&'a str>>,
+fn zip_apply<'a, R: InvokeResult>(
+    json_array: impl ArrayAccessor<Item = &'a str>,
     path_array: &ArrayRef,
-    to_array: impl Fn(C) -> DataFusionResult<ArrayRef>,
-    jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<I, GetError>,
+    jiter_find: impl Fn(Option<&'a str>, &[JsonPath]) -> Result<R::Item, GetError>,
 ) -> DataFusionResult<ArrayRef> {
-    #[allow(clippy::needless_pass_by_value)] // ArrayAccessor is implemented on references
-    fn inner<'a, 'j, P: Into<JsonPath<'a>>, C: FromIterator<Option<I>> + 'static, I>(
-        json_iter: impl IntoIterator<Item = Option<&'j str>>,
-        path_array: impl ArrayAccessor<Item = P>,
-        jiter_find: impl Fn(Option<&str>, &[JsonPath]) -> Result<I, GetError>,
-    ) -> C {
-        json_iter
-            .into_iter()
-            .enumerate()
-            .map(|(i, opt_json)| {
-                if path_array.is_null(i) {
-                    None
-                } else {
-                    let path = path_array.value(i).into();
-                    jiter_find(opt_json, &[path]).ok()
-                }
-            })
-            .collect::<C>()
+    fn get_array_values<'j, 'p, P: Into<JsonPath<'p>>>(
+        j: &impl ArrayAccessor<Item = &'j str>,
+        p: &impl ArrayAccessor<Item = P>,
+        index: usize,
+    ) -> Option<(Option<&'j str>, JsonPath<'p>)> {
+        let path = if p.is_null(index) {
+            return None;
+        } else {
+            p.value(index).into()
+        };
+
+        let json = if j.is_null(index) { None } else { Some(j.value(index)) };
+
+        Some((json, path))
     }
 
-    let c = match path_array.data_type() {
+    #[allow(clippy::needless_pass_by_value)] // ArrayAccessor is implemented on references
+    fn inner<'a, 'p, P: Into<JsonPath<'p>>, R: InvokeResult>(
+        json_array: impl ArrayAccessor<Item = &'a str>,
+        path_array: impl ArrayAccessor<Item = P>,
+        jiter_find: impl Fn(Option<&'a str>, &[JsonPath]) -> Result<R::Item, GetError>,
+    ) -> DataFusionResult<ArrayRef> {
+        let mut builder = R::builder(json_array.len());
+        for i in 0..json_array.len() {
+            if let Some((opt_json, path)) = get_array_values(&json_array, &path_array, i) {
+                let value = jiter_find(opt_json, &[path]).ok();
+                R::append_value(&mut builder, value);
+            } else {
+                R::append_value(&mut builder, None);
+            }
+        }
+        R::finish(builder)
+    }
+
+    match path_array.data_type() {
         // for string dictionaries, cast dictionary keys to larger types to avoid generic explosion
         DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::Utf8 => {
             let path_array = cast_to_large_dictionary(path_array.as_any_dictionary())?;
-            inner(
+            inner::<_, R>(
                 json_array,
                 path_array.downcast_dict::<StringArray>().unwrap(),
                 jiter_find,
@@ -358,7 +389,7 @@ fn zip_apply<'a, C: FromIterator<Option<I>> + 'static, I>(
         }
         DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::LargeUtf8 => {
             let path_array = cast_to_large_dictionary(path_array.as_any_dictionary())?;
-            inner(
+            inner::<_, R>(
                 json_array,
                 path_array.downcast_dict::<LargeStringArray>().unwrap(),
                 jiter_find,
@@ -366,7 +397,7 @@ fn zip_apply<'a, C: FromIterator<Option<I>> + 'static, I>(
         }
         DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::Utf8View => {
             let path_array = cast_to_large_dictionary(path_array.as_any_dictionary())?;
-            inner(
+            inner::<_, R>(
                 json_array,
                 path_array.downcast_dict::<StringViewArray>().unwrap(),
                 jiter_find,
@@ -374,31 +405,29 @@ fn zip_apply<'a, C: FromIterator<Option<I>> + 'static, I>(
         }
         // for integer dictionaries, cast them directly to the inner type because it basically costs
         // the same as building a new key array anyway
-        DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::Int64 => inner(
+        DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::Int64 => inner::<_, R>(
             json_array,
             cast(path_array, &DataType::Int64)?.as_primitive::<Int64Type>(),
             jiter_find,
         ),
-        DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::UInt64 => inner(
+        DataType::Dictionary(_, value_type) if value_type.as_ref() == &DataType::UInt64 => inner::<_, R>(
             json_array,
             cast(path_array, &DataType::UInt64)?.as_primitive::<UInt64Type>(),
             jiter_find,
         ),
         // for basic types, just consume directly
-        DataType::Utf8 => inner(json_array, path_array.as_string::<i32>(), jiter_find),
-        DataType::LargeUtf8 => inner(json_array, path_array.as_string::<i64>(), jiter_find),
-        DataType::Utf8View => inner(json_array, path_array.as_string_view(), jiter_find),
-        DataType::Int64 => inner(json_array, path_array.as_primitive::<Int64Type>(), jiter_find),
-        DataType::UInt64 => inner(json_array, path_array.as_primitive::<UInt64Type>(), jiter_find),
+        DataType::Utf8 => inner::<_, R>(json_array, path_array.as_string::<i32>(), jiter_find),
+        DataType::LargeUtf8 => inner::<_, R>(json_array, path_array.as_string::<i64>(), jiter_find),
+        DataType::Utf8View => inner::<_, R>(json_array, path_array.as_string_view(), jiter_find),
+        DataType::Int64 => inner::<_, R>(json_array, path_array.as_primitive::<Int64Type>(), jiter_find),
+        DataType::UInt64 => inner::<_, R>(json_array, path_array.as_primitive::<UInt64Type>(), jiter_find),
         other => {
             return exec_err!(
                 "unexpected second argument type, expected string or int array, got {:?}",
                 other
             )
         }
-    };
-
-    to_array(c)
+    }
 }
 
 fn extract_json_scalar(scalar: &ScalarValue) -> DataFusionResult<Option<&str>> {

--- a/src/common_union.rs
+++ b/src/common_union.rs
@@ -61,7 +61,7 @@ pub(crate) struct JsonUnion {
 }
 
 impl JsonUnion {
-    fn new(length: usize) -> Self {
+    pub fn new(length: usize) -> Self {
         Self {
             bools: vec![None; length],
             ints: vec![None; length],
@@ -79,7 +79,7 @@ impl JsonUnion {
         DataType::Union(union_fields(), UnionMode::Sparse)
     }
 
-    fn push(&mut self, field: JsonUnionField) {
+    pub fn push(&mut self, field: JsonUnionField) {
         self.type_ids[self.index] = field.type_id();
         match field {
             JsonUnionField::JsonNull => (),
@@ -94,7 +94,7 @@ impl JsonUnion {
         debug_assert!(self.index <= self.length);
     }
 
-    fn push_none(&mut self) {
+    pub fn push_none(&mut self) {
         self.index += 1;
         debug_assert!(self.index <= self.length);
     }

--- a/src/json_as_text.rs
+++ b/src/json_as_text.rs
@@ -50,7 +50,7 @@ impl ScalarUDFImpl for JsonAsText {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<StringArray>(args, jiter_json_as_text, true)
+        invoke::<StringArray>(args, jiter_json_as_text)
     }
 
     fn aliases(&self) -> &[String] {
@@ -62,6 +62,8 @@ impl InvokeResult for StringArray {
     type Item = String;
 
     type Builder = StringBuilder;
+
+    const ACCEPT_DICT_RETURN: bool = true;
 
     fn builder(capacity: usize) -> Self::Builder {
         StringBuilder::with_capacity(capacity, 0)

--- a/src/json_as_text.rs
+++ b/src/json_as_text.rs
@@ -70,7 +70,7 @@ impl InvokeResult for StringArray {
     }
 
     fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
-        builder.append_option(value)
+        builder.append_option(value);
     }
 
     fn finish(mut builder: Self::Builder) -> DataFusionResult<ArrayRef> {

--- a/src/json_as_text.rs
+++ b/src/json_as_text.rs
@@ -1,13 +1,13 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::array::{ArrayRef, StringArray, StringBuilder};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -50,17 +50,33 @@ impl ScalarUDFImpl for JsonAsText {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<StringArray, String>(
-            args,
-            jiter_json_as_text,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::Utf8,
-            true,
-        )
+        invoke::<StringArray>(args, jiter_json_as_text, true)
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+impl InvokeResult for StringArray {
+    type Item = String;
+
+    type Builder = StringBuilder;
+
+    fn builder(capacity: usize) -> Self::Builder {
+        StringBuilder::with_capacity(capacity, 0)
+    }
+
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
+        builder.append_option(value)
+    }
+
+    fn finish(mut builder: Self::Builder) -> DataFusionResult<ArrayRef> {
+        Ok(Arc::new(builder.finish()))
+    }
+
+    fn scalar(value: Option<Self::Item>) -> ScalarValue {
+        ScalarValue::Utf8(value)
     }
 }
 

--- a/src/json_contains.rs
+++ b/src/json_contains.rs
@@ -54,7 +54,7 @@ impl ScalarUDFImpl for JsonContains {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
-        invoke::<BooleanArray>(args, jiter_json_contains, false)
+        invoke::<BooleanArray>(args, jiter_json_contains)
     }
 
     fn aliases(&self) -> &[String] {
@@ -66,6 +66,9 @@ impl InvokeResult for BooleanArray {
     type Item = bool;
 
     type Builder = BooleanBuilder;
+
+    // Using boolean inside a dictionary is not an optimization!
+    const ACCEPT_DICT_RETURN: bool = false;
 
     fn builder(capacity: usize) -> Self::Builder {
         BooleanBuilder::with_capacity(capacity)

--- a/src/json_contains.rs
+++ b/src/json_contains.rs
@@ -1,12 +1,13 @@
 use std::any::Any;
 use std::sync::Arc;
 
+use datafusion::arrow::array::BooleanBuilder;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::arrow::array::{ArrayRef, BooleanArray};
 use datafusion::common::{plan_err, Result, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 
-use crate::common::{invoke, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -53,17 +54,33 @@ impl ScalarUDFImpl for JsonContains {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> Result<ColumnarValue> {
-        invoke::<BooleanArray, bool>(
-            args,
-            jiter_json_contains,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::Boolean,
-            false,
-        )
+        invoke::<BooleanArray>(args, jiter_json_contains, false)
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+impl InvokeResult for BooleanArray {
+    type Item = bool;
+
+    type Builder = BooleanBuilder;
+
+    fn builder(capacity: usize) -> Self::Builder {
+        BooleanBuilder::with_capacity(capacity)
+    }
+
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
+        builder.append_option(value)
+    }
+
+    fn finish(mut builder: Self::Builder) -> Result<ArrayRef> {
+        Ok(Arc::new(builder.finish()))
+    }
+
+    fn scalar(value: Option<Self::Item>) -> ScalarValue {
+        ScalarValue::Boolean(value)
     }
 }
 

--- a/src/json_contains.rs
+++ b/src/json_contains.rs
@@ -75,7 +75,7 @@ impl InvokeResult for BooleanArray {
     }
 
     fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
-        builder.append_option(value)
+        builder.append_option(value);
     }
 
     fn finish(mut builder: Self::Builder) -> Result<ArrayRef> {

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -77,9 +77,9 @@ impl InvokeResult for JsonUnion {
 
     fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
         if let Some(value) = value {
-            builder.push(value)
+            builder.push(value);
         } else {
-            builder.push_none()
+            builder.push_none();
         }
     }
 

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -6,8 +6,10 @@ use datafusion::arrow::array::UnionArray;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::Result as DataFusionResult;
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
+use datafusion::scalar::ScalarValue;
 use jiter::{Jiter, NumberAny, NumberInt, Peek};
 
+use crate::common::InvokeResult;
 use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 use crate::common_union::{JsonUnion, JsonUnionField};
@@ -54,15 +56,38 @@ impl ScalarUDFImpl for JsonGet {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        let to_array = |c: JsonUnion| {
-            let array: UnionArray = c.try_into()?;
-            Ok(Arc::new(array) as ArrayRef)
-        };
-        invoke::<JsonUnion, JsonUnionField>(args, jiter_json_get_union, to_array, JsonUnionField::scalar_value, true)
+        invoke::<JsonUnion>(args, jiter_json_get_union, true)
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+impl InvokeResult for JsonUnion {
+    type Item = JsonUnionField;
+
+    type Builder = JsonUnion;
+
+    fn builder(capacity: usize) -> Self::Builder {
+        JsonUnion::new(capacity)
+    }
+
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
+        if let Some(value) = value {
+            builder.push(value)
+        } else {
+            builder.push_none()
+        }
+    }
+
+    fn finish(builder: Self::Builder) -> DataFusionResult<ArrayRef> {
+        let array: UnionArray = builder.try_into()?;
+        Ok(Arc::new(array) as ArrayRef)
+    }
+
+    fn scalar(value: Option<Self::Item>) -> ScalarValue {
+        JsonUnionField::scalar_value(value)
     }
 }
 

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -56,7 +56,7 @@ impl ScalarUDFImpl for JsonGet {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<JsonUnion>(args, jiter_json_get_union, true)
+        invoke::<JsonUnion>(args, jiter_json_get_union)
     }
 
     fn aliases(&self) -> &[String] {
@@ -68,6 +68,8 @@ impl InvokeResult for JsonUnion {
     type Item = JsonUnionField;
 
     type Builder = JsonUnion;
+
+    const ACCEPT_DICT_RETURN: bool = true;
 
     fn builder(capacity: usize) -> Self::Builder {
         JsonUnion::new(capacity)

--- a/src/json_get_bool.rs
+++ b/src/json_get_bool.rs
@@ -1,9 +1,8 @@
 use std::any::Any;
-use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, BooleanArray};
+use datafusion::arrow::array::BooleanArray;
 use datafusion::arrow::datatypes::DataType;
-use datafusion::common::{Result as DataFusionResult, ScalarValue};
+use datafusion::common::Result as DataFusionResult;
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
@@ -50,13 +49,7 @@ impl ScalarUDFImpl for JsonGetBool {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<BooleanArray, bool>(
-            args,
-            jiter_json_get_bool,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::Boolean,
-            false,
-        )
+        invoke::<BooleanArray>(args, jiter_json_get_bool, false)
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_get_bool.rs
+++ b/src/json_get_bool.rs
@@ -49,7 +49,7 @@ impl ScalarUDFImpl for JsonGetBool {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<BooleanArray>(args, jiter_json_get_bool, false)
+        invoke::<BooleanArray>(args, jiter_json_get_bool)
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -1,13 +1,13 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, Float64Array};
+use datafusion::arrow::array::{ArrayRef, Float64Array, Float64Builder};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::{NumberAny, Peek};
 
-use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -50,17 +50,33 @@ impl ScalarUDFImpl for JsonGetFloat {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<Float64Array, f64>(
-            args,
-            jiter_json_get_float,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::Float64,
-            true,
-        )
+        invoke::<Float64Array>(args, jiter_json_get_float, true)
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+impl InvokeResult for Float64Array {
+    type Item = f64;
+
+    type Builder = Float64Builder;
+
+    fn builder(capacity: usize) -> Self::Builder {
+        Float64Builder::with_capacity(capacity)
+    }
+
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
+        builder.append_option(value)
+    }
+
+    fn finish(mut builder: Self::Builder) -> DataFusionResult<ArrayRef> {
+        Ok(Arc::new(builder.finish()))
+    }
+
+    fn scalar(value: Option<Self::Item>) -> ScalarValue {
+        ScalarValue::Float64(value)
     }
 }
 

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -71,7 +71,7 @@ impl InvokeResult for Float64Array {
     }
 
     fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
-        builder.append_option(value)
+        builder.append_option(value);
     }
 
     fn finish(mut builder: Self::Builder) -> DataFusionResult<ArrayRef> {

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -50,7 +50,7 @@ impl ScalarUDFImpl for JsonGetFloat {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<Float64Array>(args, jiter_json_get_float, true)
+        invoke::<Float64Array>(args, jiter_json_get_float)
     }
 
     fn aliases(&self) -> &[String] {
@@ -62,6 +62,9 @@ impl InvokeResult for Float64Array {
     type Item = f64;
 
     type Builder = Float64Builder;
+
+    // Cheaper to produce a float array rather than dict-encoded floats
+    const ACCEPT_DICT_RETURN: bool = false;
 
     fn builder(capacity: usize) -> Self::Builder {
         Float64Builder::with_capacity(capacity)

--- a/src/json_get_int.rs
+++ b/src/json_get_int.rs
@@ -50,7 +50,7 @@ impl ScalarUDFImpl for JsonGetInt {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<Int64Array>(args, jiter_json_get_int, true)
+        invoke::<Int64Array>(args, jiter_json_get_int)
     }
 
     fn aliases(&self) -> &[String] {
@@ -62,6 +62,9 @@ impl InvokeResult for Int64Array {
     type Item = i64;
 
     type Builder = Int64Builder;
+
+    // Cheaper to return an int array rather than dict-encoded ints
+    const ACCEPT_DICT_RETURN: bool = false;
 
     fn builder(capacity: usize) -> Self::Builder {
         Int64Builder::with_capacity(capacity)

--- a/src/json_get_int.rs
+++ b/src/json_get_int.rs
@@ -1,13 +1,13 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, Int64Array};
+use datafusion::arrow::array::{ArrayRef, Int64Array, Int64Builder};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::{NumberInt, Peek};
 
-use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -50,17 +50,33 @@ impl ScalarUDFImpl for JsonGetInt {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<Int64Array, i64>(
-            args,
-            jiter_json_get_int,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::Int64,
-            true,
-        )
+        invoke::<Int64Array>(args, jiter_json_get_int, true)
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+impl InvokeResult for Int64Array {
+    type Item = i64;
+
+    type Builder = Int64Builder;
+
+    fn builder(capacity: usize) -> Self::Builder {
+        Int64Builder::with_capacity(capacity)
+    }
+
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
+        builder.append_option(value);
+    }
+
+    fn finish(mut builder: Self::Builder) -> DataFusionResult<ArrayRef> {
+        Ok(Arc::new(builder.finish()))
+    }
+
+    fn scalar(value: Option<Self::Item>) -> ScalarValue {
+        ScalarValue::Int64(value)
     }
 }
 

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -48,7 +48,7 @@ impl ScalarUDFImpl for JsonGetJson {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<StringArray>(args, jiter_json_get_json, true)
+        invoke::<StringArray>(args, jiter_json_get_json)
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -1,9 +1,8 @@
 use std::any::Any;
-use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::DataType;
-use datafusion::common::{Result as DataFusionResult, ScalarValue};
+use datafusion::common::Result as DataFusionResult;
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 
 use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
@@ -49,13 +48,7 @@ impl ScalarUDFImpl for JsonGetJson {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<StringArray, String>(
-            args,
-            jiter_json_get_json,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::Utf8,
-            true,
-        )
+        invoke::<StringArray>(args, jiter_json_get_json, true)
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_get_str.rs
+++ b/src/json_get_str.rs
@@ -49,7 +49,7 @@ impl ScalarUDFImpl for JsonGetStr {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<StringArray>(args, jiter_json_get_str, true)
+        invoke::<StringArray>(args, jiter_json_get_str)
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_get_str.rs
+++ b/src/json_get_str.rs
@@ -1,9 +1,8 @@
 use std::any::Any;
-use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, StringArray};
+use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::DataType;
-use datafusion::common::{Result as DataFusionResult, ScalarValue};
+use datafusion::common::Result as DataFusionResult;
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
@@ -50,13 +49,7 @@ impl ScalarUDFImpl for JsonGetStr {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<StringArray, String>(
-            args,
-            jiter_json_get_str,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::Utf8,
-            true,
-        )
+        invoke::<StringArray>(args, jiter_json_get_str, true)
     }
 
     fn aliases(&self) -> &[String] {

--- a/src/json_length.rs
+++ b/src/json_length.rs
@@ -1,13 +1,13 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, UInt64Array};
+use datafusion::arrow::array::{ArrayRef, UInt64Array, UInt64Builder};
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -50,17 +50,33 @@ impl ScalarUDFImpl for JsonLength {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<UInt64Array, u64>(
-            args,
-            jiter_json_length,
-            |c| Ok(Arc::new(c) as ArrayRef),
-            ScalarValue::UInt64,
-            true,
-        )
+        invoke::<UInt64Array>(args, jiter_json_length, true)
     }
 
     fn aliases(&self) -> &[String] {
         &self.aliases
+    }
+}
+
+impl InvokeResult for UInt64Array {
+    type Item = u64;
+
+    type Builder = UInt64Builder;
+
+    fn builder(capacity: usize) -> Self::Builder {
+        UInt64Builder::with_capacity(capacity)
+    }
+
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
+        builder.append_option(value);
+    }
+
+    fn finish(mut builder: Self::Builder) -> DataFusionResult<ArrayRef> {
+        Ok(Arc::new(builder.finish()))
+    }
+
+    fn scalar(value: Option<Self::Item>) -> ScalarValue {
+        ScalarValue::UInt64(value)
     }
 }
 

--- a/src/json_length.rs
+++ b/src/json_length.rs
@@ -50,7 +50,7 @@ impl ScalarUDFImpl for JsonLength {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<UInt64Array>(args, jiter_json_length, true)
+        invoke::<UInt64Array>(args, jiter_json_length)
     }
 
     fn aliases(&self) -> &[String] {
@@ -62,6 +62,9 @@ impl InvokeResult for UInt64Array {
     type Item = u64;
 
     type Builder = UInt64Builder;
+
+    // cheaper to return integers without dict-encoding them
+    const ACCEPT_DICT_RETURN: bool = false;
 
     fn builder(capacity: usize) -> Self::Builder {
         UInt64Builder::with_capacity(capacity)

--- a/src/json_object_keys.rs
+++ b/src/json_object_keys.rs
@@ -1,13 +1,13 @@
 use std::any::Any;
 use std::sync::Arc;
 
-use datafusion::arrow::array::{ArrayRef, ListArray, ListBuilder, StringBuilder};
+use datafusion::arrow::array::{ArrayRef, ListBuilder, StringBuilder};
 use datafusion::arrow::datatypes::{DataType, Field};
 use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -54,13 +54,7 @@ impl ScalarUDFImpl for JsonObjectKeys {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<ListArrayWrapper, Vec<String>>(
-            args,
-            jiter_json_object_keys,
-            |w| Ok(Arc::new(w.0) as ArrayRef),
-            keys_to_scalar,
-            true,
-        )
+        invoke::<BuildListArray>(args, jiter_json_object_keys, true)
     }
 
     fn aliases(&self) -> &[String] {
@@ -68,25 +62,30 @@ impl ScalarUDFImpl for JsonObjectKeys {
     }
 }
 
-/// Wrapper for a `ListArray` that allows us to implement `FromIterator<Option<Vec<String>>>` as required.
+/// Struct used to build a `ListArray` from the result of `jiter_json_object_keys`.
 #[derive(Debug)]
-struct ListArrayWrapper(ListArray);
+struct BuildListArray;
 
-impl FromIterator<Option<Vec<String>>> for ListArrayWrapper {
-    fn from_iter<I: IntoIterator<Item = Option<Vec<String>>>>(iter: I) -> Self {
+impl InvokeResult for BuildListArray {
+    type Item = Vec<String>;
+
+    type Builder = ListBuilder<StringBuilder>;
+
+    fn builder(capacity: usize) -> Self::Builder {
         let values_builder = StringBuilder::new();
-        let mut builder = ListBuilder::new(values_builder);
-        for opt_keys in iter {
-            if let Some(keys) = opt_keys {
-                for value in keys {
-                    builder.values().append_value(value);
-                }
-                builder.append(true);
-            } else {
-                builder.append(false);
-            }
-        }
-        Self(builder.finish())
+        ListBuilder::with_capacity(values_builder, capacity)
+    }
+
+    fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
+        builder.append_option(value.map(|v| v.into_iter().map(Some)));
+    }
+
+    fn finish(mut builder: Self::Builder) -> DataFusionResult<ArrayRef> {
+        Ok(Arc::new(builder.finish()))
+    }
+
+    fn scalar(value: Option<Self::Item>) -> ScalarValue {
+        keys_to_scalar(value)
     }
 }
 

--- a/src/json_object_keys.rs
+++ b/src/json_object_keys.rs
@@ -54,7 +54,7 @@ impl ScalarUDFImpl for JsonObjectKeys {
     }
 
     fn invoke(&self, args: &[ColumnarValue]) -> DataFusionResult<ColumnarValue> {
-        invoke::<BuildListArray>(args, jiter_json_object_keys, true)
+        invoke::<BuildListArray>(args, jiter_json_object_keys)
     }
 
     fn aliases(&self) -> &[String] {
@@ -70,6 +70,8 @@ impl InvokeResult for BuildListArray {
     type Item = Vec<String>;
 
     type Builder = ListBuilder<StringBuilder>;
+
+    const ACCEPT_DICT_RETURN: bool = true;
 
     fn builder(capacity: usize) -> Self::Builder {
         let values_builder = StringBuilder::new();


### PR DESCRIPTION
Using `FromIterator` makes for complicated code for the optimiser; by using a custom trait to use to build values from `invoke` we end up being able to approx cut the generated code in half.

before

```
Lines                 Copies              Function name
  -----                 ------              -------------
  305729                9773                (TOTAL)
   34870 (11.4%, 11.4%)   60 (0.6%,  0.6%)  datafusion_functions_json::common::zip_apply
   25200 (8.2%, 19.6%)   480 (4.9%,  5.5%)  datafusion_functions_json::common::zip_apply::inner::{{closure}}
   24174 (7.9%, 27.6%)   153 (1.6%,  7.1%)  <arrow_array::array::primitive_array::PrimitiveArray<T> as core::iter::traits::collect::FromIterator<Ptr>>::from_iter
```

after

```
  Lines                 Copies              Function name
  -----                 ------              -------------
  142542                1737                (TOTAL)
   60312 (42.3%, 42.3%)  480 (27.6%, 27.6%) datafusion_functions_json::common::zip_apply::inner
   33540 (23.5%, 65.8%)   60 (3.5%, 31.1%)  datafusion_functions_json::common::zip_apply
    4990 (3.5%, 69.3%)    10 (0.6%, 31.7%)  datafusion_functions_json::common::invoke_array_array
```

... this is probably good enough reduction in size now.