### PR TITLE
Fix bug with handling of null values in dictionaries

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ repository = "https://github.com/datafusion-contrib/datafusion-functions-json/"
 rust-version = "1.80.1"
 
 [dependencies]
-arrow = "53.4.0"
 datafusion = { version = "44", default-features = false }
 jiter = "0.8"
 paste = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/datafusion-contrib/datafusion-functions-json/"
 rust-version = "1.80.1"
 
 [dependencies]
+arrow = "53.4.0"
 datafusion = { version = "44", default-features = false }
 jiter = "0.8"
 paste = "1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use datafusion::arrow::array::{
     downcast_array, AnyDictionaryArray, Array, ArrayAccessor, ArrayRef, AsArray, DictionaryArray, LargeStringArray,
-    PrimitiveArray, RunArray, StringArray, StringViewArray, PrimitiveBuilder
+    PrimitiveArray, PrimitiveBuilder, RunArray, StringArray, StringViewArray,
 };
 use datafusion::arrow::compute::kernels::cast;
 use datafusion::arrow::compute::take;

--- a/src/common.rs
+++ b/src/common.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 use std::str::Utf8Error;
 use std::sync::Arc;
 
-use arrow::array::PrimitiveBuilder;
 use datafusion::arrow::array::{
     downcast_array, AnyDictionaryArray, Array, ArrayAccessor, ArrayRef, AsArray, DictionaryArray, LargeStringArray,
-    PrimitiveArray, RunArray, StringArray, StringViewArray,
+    PrimitiveArray, RunArray, StringArray, StringViewArray, PrimitiveBuilder
 };
 use datafusion::arrow::compute::kernels::cast;
 use datafusion::arrow::compute::take;

--- a/src/common.rs
+++ b/src/common.rs
@@ -261,17 +261,15 @@ fn remap_dictionary_key_nulls(
 ) -> DataFusionResult<DictionaryArray<Int64Type>> {
     let mut new_keys_builder = PrimitiveBuilder::<Int64Type>::new();
     let mut value_indices_builder = PrimitiveBuilder::<Int64Type>::new();
-    let mut value_map = HashMap::new(); // Map old indices to new indices
-    let mut next_index = 0i64;
+    let mut value_map: HashMap<i64, i64> = HashMap::new(); // Map old indices to new indices
 
     // First pass: build mapping of old indices to new indices
     for key in keys.iter() {
         if let Some(k) = key {
             let k_usize = k.as_usize();
             if !values.is_null(k_usize) && !value_map.contains_key(&k) {
-                value_map.insert(k, next_index);
+                value_map.insert(k, i64::try_from(value_map.len()).expect("value_map overflow"));
                 value_indices_builder.append_value(k);
-                next_index += 1;
             }
         }
     }

--- a/src/common.rs
+++ b/src/common.rs
@@ -289,11 +289,11 @@ fn remap_dictionary_key_nulls(
             None => new_keys_builder.append_null(),
         }
     }
-    
+
     let new_keys = new_keys_builder.finish();
     let value_indices = value_indices_builder.finish();
     let new_values = take(values, &value_indices, None)?;
-    
+
     Ok(DictionaryArray::new(new_keys, new_values))
 }
 

--- a/src/common.rs
+++ b/src/common.rs
@@ -258,7 +258,7 @@ fn remap_dictionary_key_nulls(
     values: ArrayRef,
 ) -> DataFusionResult<DictionaryArray<Int64Type>> {
     // fast path: no nulls in values
-    if values.null_count() == 0{
+    if values.null_count() == 0 {
         return Ok(DictionaryArray::new(keys, values));
     }
 

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1280,11 +1280,13 @@ async fn test_dict_haystack() {
     assert_batches_eq!(expected, &batches);
 }
 
-
 fn check_for_null_dictionary_values(array: &dyn Array) {
     let array = array.as_any().downcast_ref::<DictionaryArray<Int64Type>>().unwrap();
     let keys_array = array.keys();
-    let keys = keys_array.iter().filter_map(|x| x.map(|v| usize::try_from(v).unwrap())).collect::<Vec<_>>();
+    let keys = keys_array
+        .iter()
+        .filter_map(|x| x.map(|v| usize::try_from(v).unwrap()))
+        .collect::<Vec<_>>();
     let values_array = array.values();
     // no non-null keys should point to a null value
     for i in 0..values_array.len() {
@@ -1330,20 +1332,8 @@ async fn test_dict_get_no_null_values() {
 
     let sql = "select json_get_str(x, 'baz') v from data";
     let expected = [
-        "+------+",
-        "| v    |",
-        "+------+",
-        "|      |",
-        "| fizz |",
-        "|      |",
-        "| abcd |",
-        "|      |",
-        "| fizz |",
-        "| fizz |",
-        "| fizz |",
-        "| fizz |",
-        "|      |",
-        "+------+",
+        "+------+", "| v    |", "+------+", "|      |", "| fizz |", "|      |", "| abcd |", "|      |", "| fizz |",
+        "| fizz |", "| fizz |", "| fizz |", "|      |", "+------+",
     ];
     let batches = ctx.sql(&sql).await.unwrap().collect().await.unwrap();
     assert_batches_eq!(expected, &batches);


### PR DESCRIPTION
Currently given the query `json_get_text(col, 'a')` on the data `['{'x': 0}', '{'x': 0}', '{'a': 1}']` where `col` is a dictionary encoded column originally with keys `[0, 0, 1]` and values `['{'x': 0}', '{'x': 1}']` we return a dictionary with keys `[0, 0, 1]` and values `[null, null, 1]`.
But if you look at how `arrow-rs` builds up dictionaries they always put the nulls in the keys, not the values. The [spec](https://arrow.apache.org/docs/format/Columnar.html#dictionary-encoded-layout) does not require this, but I think that things in `arrow-rs` or DataFusion assume it is so (based on panics I've seen in prod).
This PR works around those bugs elsewhere while we investigate them further.