### PR TITLE
Upgrade to Datafusion 48

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafusion-functions-json"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2021"
 description = "JSON functions for DataFusion"
 readme = "README.md"
@@ -11,16 +11,16 @@ repository = "https://github.com/datafusion-contrib/datafusion-functions-json/"
 rust-version = "1.82.0"
 
 [dependencies]
-datafusion = { version = "47", default-features = false }
+datafusion = { version = "48", default-features = false }
 jiter = "0.9"
 paste = "1"
 log = "0.4"
 
 [dev-dependencies]
-datafusion = { version = "47", default-features = false, features = ["nested_expressions"] }
+datafusion = { version = "48", default-features = false, features = [
+    "nested_expressions",
+] }
 codspeed-criterion-compat = "2.6"
-criterion = "0.5.1"
-clap = "4"
 tokio = { version = "1.43", features = ["full"] }
 
 [lints.clippy]

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -80,7 +80,7 @@ fn unnest_json_calls(func: &ScalarFunction) -> Option<Transformed<Expr>> {
     let mut args = inner_func.args.clone();
     args.extend(outer_args_iter.cloned());
     // See #23, unnest only when all lookup arguments are literals
-    if args.iter().skip(1).all(|arg| matches!(arg, Expr::Literal(_))) {
+    if args.iter().skip(1).all(|arg| matches!(arg, Expr::Literal(_, _))) {
         Some(Transformed::yes(Expr::ScalarFunction(ScalarFunction {
             func: func.func.clone(),
             args,
@@ -149,7 +149,7 @@ fn expr_to_sql_repr(expr: &Expr) -> String {
             .as_ref()
             .map_or_else(|| name.clone(), |r| format!("{r}.{name}")),
         Expr::Alias(alias) => alias.name.clone(),
-        Expr::Literal(scalar) => match scalar {
+        Expr::Literal(scalar, _) => match scalar {
             ScalarValue::Utf8(Some(v)) | ScalarValue::Utf8View(Some(v)) | ScalarValue::LargeUtf8(Some(v)) => {
                 format!("'{v}'")
             }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -503,8 +503,13 @@ fn test_json_get_utf8() {
     let ColumnarValue::Scalar(sv) = json_get_str
         .invoke_with_args(ScalarFunctionArgs {
             args: args.to_vec(),
+            arg_fields: vec![
+                Arc::new(Field::new("arg_1", DataType::LargeUtf8, false)),
+                Arc::new(Field::new("arg_2", DataType::LargeUtf8, false)),
+                Arc::new(Field::new("arg_3", DataType::LargeUtf8, false)),
+            ],
             number_rows: 1,
-            return_type: &DataType::Utf8,
+            return_field: Arc::new(Field::new("ret_field", DataType::Utf8, false)),
         })
         .unwrap()
     else {
@@ -528,8 +533,13 @@ fn test_json_get_large_utf8() {
     let ColumnarValue::Scalar(sv) = json_get_str
         .invoke_with_args(ScalarFunctionArgs {
             args: args.to_vec(),
+            arg_fields: vec![
+                Arc::new(Field::new("arg_1", DataType::LargeUtf8, false)),
+                Arc::new(Field::new("arg_2", DataType::LargeUtf8, false)),
+                Arc::new(Field::new("arg_3", DataType::LargeUtf8, false)),
+            ],
             number_rows: 1,
-            return_type: &DataType::LargeUtf8,
+            return_field: Arc::new(Field::new("ret_field", DataType::Utf8, false)),
         })
         .unwrap()
     else {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, ArrayRef, DictionaryArray, RecordBatch};
@@ -509,7 +510,10 @@ fn test_json_get_utf8() {
                 Arc::new(Field::new("arg_3", DataType::LargeUtf8, false)),
             ],
             number_rows: 1,
-            return_field: Arc::new(Field::new("ret_field", DataType::Utf8, false)),
+            return_field: Arc::new(
+                Field::new("ret_field", DataType::Utf8, false)
+                    .with_metadata(HashMap::from_iter(vec![("is_json".to_string(), "true".to_string())])),
+            ),
         })
         .unwrap()
     else {
@@ -539,7 +543,10 @@ fn test_json_get_large_utf8() {
                 Arc::new(Field::new("arg_3", DataType::LargeUtf8, false)),
             ],
             number_rows: 1,
-            return_field: Arc::new(Field::new("ret_field", DataType::Utf8, false)),
+            return_field: Arc::new(
+                Field::new("ret_field", DataType::Utf8, false)
+                    .with_metadata(HashMap::from_iter(vec![("is_json".to_string(), "true".to_string())])),
+            ),
         })
         .unwrap()
     else {


### PR DESCRIPTION
This commit accounts for breaking changes in Datafusion 48. [See upgrading guide](https://github.com/apache/datafusion/blob/main/docs/source/library-user-guide/upgrading.md#datafusion-4800).

Here are the things that break:
- ScalarFunctionArgs now take in Fields rather than purely DataTypes. Since it is quite trivial to work around them as it purely contains metadata, I've forged it for now.