### PR TITLE
Prepare for DataFusion 54

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .idea
+.history

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,3 @@ harness = false
 # datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "d47bd599ee911eb4be018595b860341ff437ccb1" }
 # datafusion-datasource = { git = "https://github.com/apache/datafusion.git", rev = "d47bd599ee911eb4be018595b860341ff437ccb1" }
 # datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion.git", rev = "d47bd599ee911eb4be018595b860341ff437ccb1" }
-
-# TEMP — remove before merging. DataFusion 54 is not yet published to crates.io,
-# so build/test against the release-candidate branch to confirm the upgrade works.
-[patch.crates-io]
-datafusion = { git = "https://github.com/apache/datafusion.git", branch = "branch-54" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/datafusion-contrib/datafusion-functions-json/"
 rust-version = "1.88.0"
 
 [dependencies]
-datafusion = { version = "53.0.0", default-features = false, features = [
+datafusion = { version = "54", default-features = false, features = [
     "sql",
 ] }
 jiter = "0.13.0"
@@ -21,7 +21,7 @@ serde_json = "1"
 
 [dev-dependencies]
 codspeed-criterion-compat = "2.6"
-datafusion = { version = "53.0.0", default-features = false, features = [
+datafusion = { version = "54", default-features = false, features = [
     "nested_expressions",
     "sql",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,3 +48,8 @@ harness = false
 # datafusion-proto = { git = "https://github.com/apache/datafusion.git", rev = "d47bd599ee911eb4be018595b860341ff437ccb1" }
 # datafusion-datasource = { git = "https://github.com/apache/datafusion.git", rev = "d47bd599ee911eb4be018595b860341ff437ccb1" }
 # datafusion-physical-expr-adapter = { git = "https://github.com/apache/datafusion.git", rev = "d47bd599ee911eb4be018595b860341ff437ccb1" }
+
+# TEMP — remove before merging. DataFusion 54 is not yet published to crates.io,
+# so build/test against the release-candidate branch to confirm the upgrade works.
+[patch.crates-io]
+datafusion = { git = "https://github.com/apache/datafusion.git", branch = "branch-54" }

--- a/src/json_as_text.rs
+++ b/src/json_as_text.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, StringArray, StringBuilder};
@@ -33,9 +32,6 @@ impl Default for JsonAsText {
 }
 
 impl ScalarUDFImpl for JsonAsText {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_as_text.rs
+++ b/src/json_as_text.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, StringArray, StringBuilder};
@@ -33,10 +32,6 @@ impl Default for JsonAsText {
 }
 
 impl ScalarUDFImpl for JsonAsText {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_contains.rs
+++ b/src/json_contains.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::BooleanBuilder;
@@ -33,9 +32,6 @@ impl Default for JsonContains {
 }
 
 impl ScalarUDFImpl for JsonContains {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_contains.rs
+++ b/src/json_contains.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::BooleanBuilder;
@@ -33,10 +32,6 @@ impl Default for JsonContains {
 }
 
 impl ScalarUDFImpl for JsonContains {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_from_scalar.rs
+++ b/src/json_from_scalar.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, UnionArray};
@@ -35,9 +34,6 @@ impl Default for JsonFromScalar {
 }
 
 impl ScalarUDFImpl for JsonFromScalar {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_from_scalar.rs
+++ b/src/json_from_scalar.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, ArrayRef, AsArray, UnionArray};
@@ -35,10 +34,6 @@ impl Default for JsonFromScalar {
 }
 
 impl ScalarUDFImpl for JsonFromScalar {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::ArrayRef;
@@ -39,9 +38,6 @@ impl Default for JsonGet {
 }
 
 impl ScalarUDFImpl for JsonGet {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_get.rs
+++ b/src/json_get.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::ArrayRef;
@@ -39,10 +38,6 @@ impl Default for JsonGet {
 }
 
 impl ScalarUDFImpl for JsonGet {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_get_array.rs
+++ b/src/json_get_array.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, ListBuilder, StringBuilder};
@@ -33,9 +32,6 @@ impl Default for JsonGetArray {
 }
 
 impl ScalarUDFImpl for JsonGetArray {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_get_array.rs
+++ b/src/json_get_array.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, ListBuilder, StringBuilder};
@@ -38,10 +37,6 @@ impl Default for JsonGetArray {
 }
 
 impl ScalarUDFImpl for JsonGetArray {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_get_bool.rs
+++ b/src/json_get_bool.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 
 use datafusion::arrow::array::BooleanArray;
 use datafusion::arrow::datatypes::DataType;
@@ -32,9 +31,6 @@ impl Default for JsonGetBool {
 }
 
 impl ScalarUDFImpl for JsonGetBool {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_get_bool.rs
+++ b/src/json_get_bool.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use datafusion::arrow::array::BooleanArray;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::Result as DataFusionResult;
@@ -32,10 +30,6 @@ impl Default for JsonGetBool {
 }
 
 impl ScalarUDFImpl for JsonGetBool {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, Float64Array, Float64Builder};
@@ -33,9 +32,6 @@ impl Default for JsonGetFloat {
 }
 
 impl ScalarUDFImpl for JsonGetFloat {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_get_float.rs
+++ b/src/json_get_float.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, Float64Array, Float64Builder};
@@ -33,10 +32,6 @@ impl Default for JsonGetFloat {
 }
 
 impl ScalarUDFImpl for JsonGetFloat {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_get_int.rs
+++ b/src/json_get_int.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, Int64Array, Int64Builder};
@@ -33,9 +32,6 @@ impl Default for JsonGetInt {
 }
 
 impl ScalarUDFImpl for JsonGetInt {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_get_int.rs
+++ b/src/json_get_int.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, Int64Array, Int64Builder};
@@ -33,10 +32,6 @@ impl Default for JsonGetInt {
 }
 
 impl ScalarUDFImpl for JsonGetInt {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 
 use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::DataType;
@@ -31,9 +30,6 @@ impl Default for JsonGetJson {
 }
 
 impl ScalarUDFImpl for JsonGetJson {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::StringArray;
@@ -35,10 +34,6 @@ impl Default for JsonGetJson {
 }
 
 impl ScalarUDFImpl for JsonGetJson {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_get_str.rs
+++ b/src/json_get_str.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 
 use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::DataType;
@@ -32,9 +31,6 @@ impl Default for JsonGetStr {
 }
 
 impl ScalarUDFImpl for JsonGetStr {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_get_str.rs
+++ b/src/json_get_str.rs
@@ -1,5 +1,3 @@
-use std::any::Any;
-
 use datafusion::arrow::array::StringArray;
 use datafusion::arrow::datatypes::DataType;
 use datafusion::common::Result as DataFusionResult;
@@ -32,10 +30,6 @@ impl Default for JsonGetStr {
 }
 
 impl ScalarUDFImpl for JsonGetStr {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_length.rs
+++ b/src/json_length.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, UInt64Array, UInt64Builder};
@@ -33,9 +32,6 @@ impl Default for JsonLength {
 }
 
 impl ScalarUDFImpl for JsonLength {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_length.rs
+++ b/src/json_length.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, UInt64Array, UInt64Builder};
@@ -33,10 +32,6 @@ impl Default for JsonLength {
 }
 
 impl ScalarUDFImpl for JsonLength {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_object_keys.rs
+++ b/src/json_object_keys.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, ListBuilder, StringBuilder};
@@ -33,9 +32,6 @@ impl Default for JsonObjectKeys {
 }
 
 impl ScalarUDFImpl for JsonObjectKeys {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
 
     fn name(&self) -> &str {
         self.aliases[0].as_str()

--- a/src/json_object_keys.rs
+++ b/src/json_object_keys.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, ListBuilder, StringBuilder};
@@ -33,10 +32,6 @@ impl Default for JsonObjectKeys {
 }
 
 impl ScalarUDFImpl for JsonObjectKeys {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/json_union_to_text.rs
+++ b/src/json_union_to_text.rs
@@ -1,4 +1,3 @@
-use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, ArrayRef, StringViewBuilder, UnionArray};
@@ -43,10 +42,6 @@ impl Default for JsonUnionToText {
 }
 
 impl ScalarUDFImpl for JsonUnionToText {
-    fn as_any(&self) -> &dyn Any {
-        self
-    }
-
     fn name(&self) -> &str {
         self.aliases[0].as_str()
     }

--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -38,7 +38,7 @@ fn optimise_json_get_cast(cast: &Cast) -> Option<Transformed<Expr>> {
     if scalar_func.func.name() != "json_get" {
         return None;
     }
-    let func = match &cast.data_type {
+    let func = match cast.field.data_type() {
         DataType::Boolean => crate::json_get_bool::json_get_bool_udf(),
         DataType::Float64 | DataType::Float32 | DataType::Decimal128(_, _) | DataType::Decimal256(_, _) => {
             crate::json_get_float::json_get_float_udf()


### PR DESCRIPTION
## Summary
- Remove `as_any()` from all `ScalarUDFImpl` implementations (removed from the trait in DataFusion 54)
- Fix `Cast::data_type` → `Cast::field.data_type()` (struct field changed in DataFusion 54)

Based on the v0.53.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)