### PR TITLE
Mark JSON-bearing string fields with is_json metadata

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::str::Utf8Error;
 use std::sync::Arc;
 
@@ -16,13 +15,6 @@ use jiter::{Jiter, JiterError, Peek};
 use crate::common_union::{
     is_json_union, json_from_union_scalar, nested_json_array, nested_json_array_ref, TYPE_ID_NULL,
 };
-
-/// Field metadata that marks a `Utf8` column/field as containing raw JSON.
-/// Downstream consumers (e.g. the rewrite layer, other UDFs) use this to
-/// recognize JSON-bearing string columns.
-pub fn is_json_metadata() -> HashMap<String, String> {
-    HashMap::from([("is_json".to_string(), "true".to_string())])
-}
 
 /// General implementation of `ScalarUDFImpl::return_type`.
 ///

--- a/src/common.rs
+++ b/src/common.rs
@@ -21,7 +21,7 @@ use crate::common_union::{
 /// Downstream consumers (e.g. the rewrite layer, other UDFs) use this to
 /// recognize JSON-bearing string columns.
 pub fn is_json_metadata() -> HashMap<String, String> {
-    HashMap::from_iter(vec![("is_json".to_string(), "true".to_string())])
+    HashMap::from([("is_json".to_string(), "true".to_string())])
 }
 
 /// General implementation of `ScalarUDFImpl::return_type`.

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::str::Utf8Error;
 use std::sync::Arc;
 
@@ -15,6 +16,13 @@ use jiter::{Jiter, JiterError, Peek};
 use crate::common_union::{
     is_json_union, json_from_union_scalar, nested_json_array, nested_json_array_ref, TYPE_ID_NULL,
 };
+
+/// Field metadata that marks a `Utf8` column/field as containing raw JSON.
+/// Downstream consumers (e.g. the rewrite layer, other UDFs) use this to
+/// recognize JSON-bearing string columns.
+pub fn is_json_metadata() -> HashMap<String, String> {
+    HashMap::from_iter(vec![("is_json".to_string(), "true".to_string())])
+}
 
 /// General implementation of `ScalarUDFImpl::return_type`.
 ///

--- a/src/common_union.rs
+++ b/src/common_union.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, OnceLock};
 
 use datafusion::arrow::array::{
@@ -8,6 +7,8 @@ use datafusion::arrow::buffer::{Buffer, ScalarBuffer};
 use datafusion::arrow::datatypes::{DataType, Field, UnionFields, UnionMode};
 use datafusion::arrow::error::ArrowError;
 use datafusion::common::ScalarValue;
+
+use crate::common::is_json_metadata;
 
 pub fn is_json_union(data_type: &DataType) -> bool {
     match data_type {
@@ -161,8 +162,6 @@ fn union_fields() -> UnionFields {
     static FIELDS: OnceLock<UnionFields> = OnceLock::new();
     FIELDS
         .get_or_init(|| {
-            let json_metadata: HashMap<String, String> =
-                HashMap::from_iter(vec![("is_json".to_string(), "true".to_string())]);
             UnionFields::from_iter([
                 (TYPE_ID_NULL, Arc::new(Field::new("null", DataType::Null, true))),
                 (TYPE_ID_BOOL, Arc::new(Field::new("bool", DataType::Boolean, false))),
@@ -171,11 +170,11 @@ fn union_fields() -> UnionFields {
                 (TYPE_ID_STR, Arc::new(Field::new("str", DataType::Utf8, false))),
                 (
                     TYPE_ID_ARRAY,
-                    Arc::new(Field::new("array", DataType::Utf8, false).with_metadata(json_metadata.clone())),
+                    Arc::new(Field::new("array", DataType::Utf8, false).with_metadata(is_json_metadata())),
                 ),
                 (
                     TYPE_ID_OBJECT,
-                    Arc::new(Field::new("object", DataType::Utf8, false).with_metadata(json_metadata.clone())),
+                    Arc::new(Field::new("object", DataType::Utf8, false).with_metadata(is_json_metadata())),
                 ),
             ])
         })

--- a/src/common_union.rs
+++ b/src/common_union.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::{Arc, LazyLock, OnceLock};
 
 use datafusion::arrow::array::{
@@ -8,7 +9,13 @@ use datafusion::arrow::datatypes::{DataType, Field, UnionFields, UnionMode};
 use datafusion::arrow::error::ArrowError;
 use datafusion::common::ScalarValue;
 
-use crate::common::is_json_metadata;
+/// Field metadata used to mark a `Utf8` field as containing raw JSON.
+///
+/// Attach this to any Arrow `Field` whose values are JSON-encoded strings so
+/// downstream consumers can recognize them as JSON rather than opaque text.
+pub fn json_field_metadata() -> HashMap<String, String> {
+    HashMap::from([("is_json".to_string(), "true".to_string())])
+}
 
 pub fn is_json_union(data_type: &DataType) -> bool {
     match data_type {
@@ -170,11 +177,11 @@ fn union_fields() -> UnionFields {
                 (TYPE_ID_STR, Arc::new(Field::new("str", DataType::Utf8, false))),
                 (
                     TYPE_ID_ARRAY,
-                    Arc::new(Field::new("array", DataType::Utf8, false).with_metadata(is_json_metadata())),
+                    Arc::new(Field::new("array", DataType::Utf8, false).with_metadata(json_field_metadata())),
                 ),
                 (
                     TYPE_ID_OBJECT,
-                    Arc::new(Field::new("object", DataType::Utf8, false).with_metadata(is_json_metadata())),
+                    Arc::new(Field::new("object", DataType::Utf8, false).with_metadata(json_field_metadata())),
                 ),
             ])
         })

--- a/src/json_get_array.rs
+++ b/src/json_get_array.rs
@@ -7,13 +7,12 @@ use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{
-    get_err, invoke, is_json_metadata, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath,
-};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
 use crate::common_macros::make_udf_function;
+use crate::common_union::json_field_metadata;
 
 fn list_item_field() -> Field {
-    Field::new("item", DataType::Utf8, true).with_metadata(is_json_metadata())
+    Field::new("item", DataType::Utf8, true).with_metadata(json_field_metadata())
 }
 
 make_udf_function!(

--- a/src/json_get_array.rs
+++ b/src/json_get_array.rs
@@ -2,13 +2,19 @@ use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{ArrayRef, ListBuilder, StringBuilder};
-use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::datatypes::{DataType, Field};
 use datafusion::common::{Result as DataFusionResult, ScalarValue};
 use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
 use jiter::Peek;
 
-use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath};
+use crate::common::{
+    get_err, invoke, is_json_metadata, jiter_json_find, return_type_check, GetError, InvokeResult, JsonPath,
+};
 use crate::common_macros::make_udf_function;
+
+fn list_item_field() -> Field {
+    Field::new("item", DataType::Utf8, true).with_metadata(is_json_metadata())
+}
 
 make_udf_function!(
     JsonGetArray,
@@ -46,15 +52,7 @@ impl ScalarUDFImpl for JsonGetArray {
     }
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
-        return_type_check(
-            arg_types,
-            self.name(),
-            DataType::List(Arc::new(datafusion::arrow::datatypes::Field::new(
-                "item",
-                DataType::Utf8,
-                true,
-            ))),
-        )
+        return_type_check(arg_types, self.name(), DataType::List(Arc::new(list_item_field())))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
@@ -96,7 +94,7 @@ impl InvokeResult for BuildArrayList {
 
     fn builder(capacity: usize) -> Self::Builder {
         let values_builder = StringBuilder::new();
-        ListBuilder::with_capacity(values_builder, capacity)
+        ListBuilder::with_capacity(values_builder, capacity).with_field(list_item_field())
     }
 
     fn append_value(builder: &mut Self::Builder, value: Option<Self::Item>) {
@@ -108,7 +106,7 @@ impl InvokeResult for BuildArrayList {
     }
 
     fn scalar(value: Option<Self::Item>) -> ScalarValue {
-        let mut builder = ListBuilder::new(StringBuilder::new());
+        let mut builder = ListBuilder::new(StringBuilder::new()).with_field(list_item_field());
 
         if let Some(array_items) = value {
             for item in array_items {

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -8,8 +8,9 @@ use datafusion::logical_expr::{
     ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
 };
 
-use crate::common::{get_err, invoke, is_json_metadata, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
+use crate::common_union::json_field_metadata;
 
 make_udf_function!(
     JsonGetJson,
@@ -54,7 +55,7 @@ impl ScalarUDFImpl for JsonGetJson {
         let arg_types: Vec<DataType> = args.arg_fields.iter().map(|f| f.data_type().clone()).collect();
         let return_type = self.return_type(&arg_types)?;
         Ok(Arc::new(
-            Field::new(self.name(), return_type, true).with_metadata(is_json_metadata()),
+            Field::new(self.name(), return_type, true).with_metadata(json_field_metadata()),
         ))
     }
 

--- a/src/json_get_json.rs
+++ b/src/json_get_json.rs
@@ -1,11 +1,14 @@
 use std::any::Any;
+use std::sync::Arc;
 
 use datafusion::arrow::array::StringArray;
-use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::common::Result as DataFusionResult;
-use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion::logical_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
 
-use crate::common::{get_err, invoke, jiter_json_find, return_type_check, GetError, JsonPath};
+use crate::common::{get_err, invoke, is_json_metadata, jiter_json_find, return_type_check, GetError, JsonPath};
 use crate::common_macros::make_udf_function;
 
 make_udf_function!(
@@ -45,6 +48,14 @@ impl ScalarUDFImpl for JsonGetJson {
 
     fn return_type(&self, arg_types: &[DataType]) -> DataFusionResult<DataType> {
         return_type_check(arg_types, self.name(), DataType::Utf8)
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> DataFusionResult<FieldRef> {
+        let arg_types: Vec<DataType> = args.arg_fields.iter().map(|f| f.data_type().clone()).collect();
+        let return_type = self.return_type(&arg_types)?;
+        Ok(Arc::new(
+            Field::new(self.name(), return_type, true).with_metadata(is_json_metadata()),
+        ))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -172,11 +172,18 @@ async fn test_json_get_array_inner_field_is_json_metadata() {
     };
     assert_eq!(inner_field.metadata().get("is_json").map(String::as_str), Some("true"));
 
-    let array_field = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::ListArray>().unwrap();
+    let array_field = batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<datafusion::arrow::array::ListArray>()
+        .unwrap();
     let DataType::List(produced_inner) = array_field.data_type() else {
         panic!("expected List in produced array");
     };
-    assert_eq!(produced_inner.metadata().get("is_json").map(String::as_str), Some("true"));
+    assert_eq!(
+        produced_inner.metadata().get("is_json").map(String::as_str),
+        Some("true")
+    );
 }
 
 #[tokio::test]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -162,6 +162,24 @@ async fn test_json_get_array_with_path() {
 }
 
 #[tokio::test]
+async fn test_json_get_array_inner_field_is_json_metadata() {
+    let sql = r#"select json_get_array('[{"a": 1}, {"b": 2}]') as v"#;
+    let batches = run_query(sql).await.unwrap();
+    let schema = batches[0].schema();
+    let field = schema.field(0);
+    let DataType::List(inner_field) = field.data_type() else {
+        panic!("expected List, got {:?}", field.data_type());
+    };
+    assert_eq!(inner_field.metadata().get("is_json").map(String::as_str), Some("true"));
+
+    let array_field = batches[0].column(0).as_any().downcast_ref::<datafusion::arrow::array::ListArray>().unwrap();
+    let DataType::List(produced_inner) = array_field.data_type() else {
+        panic!("expected List in produced array");
+    };
+    assert_eq!(produced_inner.metadata().get("is_json").map(String::as_str), Some("true"));
+}
+
+#[tokio::test]
 async fn test_json_get_equals() {
     let e = run_query(r"select name, json_get(json_data, 'foo')='abc' from test")
         .await
@@ -409,6 +427,15 @@ async fn test_json_get_json_float() {
     let sql = r#"select json_get_json('{"x": 4.2e-1}', 'x')"#;
     let batches = run_query(sql).await.unwrap();
     assert_eq!(display_val(batches).await, (DataType::Utf8, "4.2e-1".to_string()));
+}
+
+#[tokio::test]
+async fn test_json_get_json_is_json_metadata() {
+    let sql = r#"select json_get_json('{"x": [1, 2]}', 'x') as v"#;
+    let batches = run_query(sql).await.unwrap();
+    let schema = batches[0].schema();
+    let field = schema.field(0);
+    assert_eq!(field.metadata().get("is_json").map(String::as_str), Some("true"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- `json_get_array` returns `List<Utf8>` whose items are raw JSON strings, but the inner field was missing the `is_json: true` field metadata. This adds it on both the declared return type and the produced `ListArray` (via `ListBuilder::with_field`), so downstream consumers can detect that the items are JSON.
- `json_get_json` returns `Utf8` containing a raw JSON sub-document; added `is_json: true` on the top-level return field via `return_field_from_args`.
- Centralized the metadata into a shared `is_json_metadata()` helper in `common.rs` and reused it in `common_union.rs` (was duplicated inline).

## Audit notes

While auditing, I checked every UDF for missing JSON metadata:

| UDF | Returns JSON? | Status |
|---|---|---|
| `json_get_array` | Inner `Utf8` items are JSON | Fixed |
| `json_get_json` | Top-level `Utf8` is raw JSON | Fixed |
| `json_get` / `json_from_scalar` | `JsonUnion` (array/object members are JSON) | Already correct via `union_fields()` |
| `json_as_text` | Mixed — strings are unwrapped, only objects/arrays return JSON | Intentionally not marked (would be misleading) |
| `json_object_keys` | List of object keys (plain strings) | N/A |
| `json_get_str/int/float/bool`, `json_length`, `json_contains` | Primitives | N/A |

`json_as_text` is intentionally left unmarked because for `Peek::String` it returns the unescaped string value (no surrounding quotes), so the output is not consistently valid JSON. Happy to revisit if you'd prefer it marked.

## Test plan

- [x] `cargo test` — all 154 tests pass
- [x] `cargo clippy --all-targets` — clean
- [x] New test `test_json_get_array_inner_field_is_json_metadata` verifies the inner field metadata both in schema and in the produced `ListArray`
- [x] New test `test_json_get_json_is_json_metadata` verifies the top-level field metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)