### PR TITLE
Bump version to 0.53.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafusion-functions-json"
-version = "0.53.0"
+version = "0.53.1"
 edition = "2021"
 description = "JSON functions for DataFusion"
 readme = "README.md"


### PR DESCRIPTION
Bumps the crate version to 0.53.1 to ship the JSON Arrow extension metadata work that was intended for the v0.53.1 release (the previous release attempt published with the version still at 0.53.0).

## Test plan
- [ ] CI passes