### PR TITLE
Mark json_union_to_text output as the canonical Arrow JSON extension type

### DIFF
--- a/src/json_union_to_text.rs
+++ b/src/json_union_to_text.rs
@@ -2,12 +2,14 @@ use std::any::Any;
 use std::sync::Arc;
 
 use datafusion::arrow::array::{Array, ArrayRef, StringViewBuilder, UnionArray};
-use datafusion::arrow::datatypes::DataType;
+use datafusion::arrow::datatypes::{DataType, Field, FieldRef};
 use datafusion::common::{exec_datafusion_err, exec_err, plan_err, Result as DataFusionResult};
-use datafusion::logical_expr::{ColumnarValue, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility};
+use datafusion::logical_expr::{
+    ColumnarValue, ReturnFieldArgs, ScalarFunctionArgs, ScalarUDFImpl, Signature, Volatility,
+};
 
 use crate::common_macros::make_udf_function;
-use crate::common_union::{is_json_union, JsonUnionEncoder, JsonUnionValue, JSON_UNION_DATA_TYPE};
+use crate::common_union::{is_json_union, json_field_metadata, JsonUnionEncoder, JsonUnionValue, JSON_UNION_DATA_TYPE};
 
 make_udf_function!(
     JsonUnionToText,
@@ -58,6 +60,14 @@ impl ScalarUDFImpl for JsonUnionToText {
             [t] if is_json_union(t) => Ok(DataType::Utf8View),
             _ => plan_err!("json_union_to_text expects a single JSON-union argument, got {arg_types:?}"),
         }
+    }
+
+    fn return_field_from_args(&self, args: ReturnFieldArgs) -> DataFusionResult<FieldRef> {
+        let arg_types: Vec<DataType> = args.arg_fields.iter().map(|f| f.data_type().clone()).collect();
+        let return_type = self.return_type(&arg_types)?;
+        Ok(Arc::new(
+            Field::new(self.name(), return_type, true).with_metadata(json_field_metadata()),
+        ))
     }
 
     fn invoke_with_args(&self, args: ScalarFunctionArgs) -> DataFusionResult<ColumnarValue> {
@@ -149,6 +159,23 @@ mod tests {
                 Some(r#"{"a":1}"#),               // Object (passthrough)
                 None,                             // None
             ]
+        );
+    }
+
+    #[test]
+    fn output_field_is_marked_as_json() {
+        let udf = JsonUnionToText::default();
+        let arg = Arc::new(Field::new("j", JSON_UNION_DATA_TYPE.clone(), true));
+        let field = udf
+            .return_field_from_args(ReturnFieldArgs {
+                arg_fields: std::slice::from_ref(&arg),
+                scalar_arguments: &[],
+            })
+            .unwrap();
+        assert_eq!(field.data_type(), &DataType::Utf8View);
+        assert_eq!(
+            field.metadata().get("ARROW:extension:name").map(String::as_str),
+            Some("arrow.json")
         );
     }
 }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -2711,3 +2711,75 @@ async fn test_json_from_scalar_null_column() {
     ];
     assert_batches_eq!(expected, &batches);
 }
+
+#[tokio::test]
+async fn test_json_union_to_text() {
+    // Flatten the heterogeneous union from `json_get` to JSON text, exercising the
+    // str / array (list member) / object / null arms in a single batch.
+    let batches = run_query("select name, json_union_to_text(json_get(json_data, 'foo')) as foo from test")
+        .await
+        .unwrap();
+
+    let expected = [
+        "+------------------+-------+",
+        "| name             | foo   |",
+        "+------------------+-------+",
+        "| object_foo       | \"abc\" |",
+        "| object_foo_array | [1]   |",
+        "| object_foo_obj   | {}    |",
+        "| object_foo_null  |       |",
+        "| object_bar       |       |",
+        "| list_foo         |       |",
+        "| invalid_json     |       |",
+        "+------------------+-------+",
+    ];
+    assert_batches_eq!(expected, &batches);
+
+    // The output column is tagged with the canonical Arrow JSON extension type.
+    let field = batches[0].schema().field_with_name("foo").unwrap().clone();
+    assert_eq!(field.data_type(), &DataType::Utf8View);
+    assert_eq!(
+        field.metadata().get("ARROW:extension:name").map(String::as_str),
+        Some("arrow.json")
+    );
+    assert_eq!(field.metadata(), &json_field_metadata());
+}
+
+#[tokio::test]
+async fn test_json_union_to_text_arms() {
+    // array and object arms already hold raw JSON text and pass through verbatim,
+    // including nested structures.
+    let (dt, repr) = display_val(
+        run_query(r#"select json_union_to_text(json_get('{"a": [1, {"b": 2}]}', 'a'))"#)
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(dt, DataType::Utf8View);
+    assert_eq!(repr, r#"[1, {"b": 2}]"#);
+
+    // string scalars are JSON-quoted and escaped (here: embedded quote + newline)
+    let (_, repr) = display_val(
+        run_query(r#"select json_union_to_text(json_get('{"s": "a\"b\n"}', 's'))"#)
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(repr, r#""a\"b\n""#);
+
+    // numbers and booleans render as bare JSON literals
+    let (_, repr) = display_val(
+        run_query(r#"select json_union_to_text(json_get('{"n": 42}', 'n'))"#)
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(repr, "42");
+    let (_, repr) = display_val(
+        run_query(r#"select json_union_to_text(json_get('{"b": true}', 'b'))"#)
+            .await
+            .unwrap(),
+    )
+    .await;
+    assert_eq!(repr, "true");
+}


### PR DESCRIPTION
Follow-up to #114. That PR added `json_union_to_text` but only overrode `return_type`, which returns a bare `DataType` — so the `Utf8View` output carried no field metadata and wasn't recognized as JSON.

This implements `return_field_from_args` to return a field tagged via `json_field_metadata()` (`ARROW:extension:name = arrow.json`, `ARROW:extension:metadata = {}`, legacy `is_json`), exactly as `json_get_json` / `json_get_array` do. The function's output (canonical JSON text) is now a proper [canonical Arrow JSON extension](https://arrow.apache.org/docs/format/CanonicalExtensions.html#json) field.

Added a test asserting the output field's `ARROW:extension:name == "arrow.json"`.

Tested: `cargo test --lib json_union_to_text`, `cargo clippy --all-targets` (pedantic), `cargo fmt --check`.