### PR TITLE
Bump version to 0.54.1 and update jiter to 0.15

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "datafusion-functions-json"
-version = "0.54.0"
+version = "0.54.1"
 edition = "2021"
 description = "JSON functions for DataFusion"
 readme = "README.md"
@@ -14,7 +14,7 @@ rust-version = "1.88.0"
 datafusion = { version = "54", default-features = false, features = [
     "sql",
 ] }
-jiter = "0.13.0"
+jiter = "0.15.0"
 log = "0.4"
 paste = "1"
 serde_json = "1"


### PR DESCRIPTION
## Summary
- Bump `version` 0.54.0 → 0.54.1
- Update `jiter` 0.13.0 → 0.15.0
- `log` left at `0.4` (already resolves to the latest 0.4.x)

Build and full test suite pass locally against jiter 0.15.

Once merged, push the `v0.54.1` tag to trigger the crates.io release.

> Note: the previously mislabeled `v0.54.1` tag (which pointed at the 0.54.0 bump commit and published 0.54.0) has been corrected to `v0.54.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)