### PR TITLE
ci: pin GitHub Actions to latest versions by commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,16 +12,17 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-    - uses: dtolnay/rust-toolchain@stable
+    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
       with:
+        toolchain: stable
         components: rustfmt, clippy
 
     - id: cache-rust
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
       with:
         extra_args: --all-files --verbose
       env:
@@ -33,10 +34,10 @@ jobs:
     outputs:
       MSRV: ${{ steps.resolve-msrv.outputs.MSRV }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: set up python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12'
 
@@ -61,20 +62,22 @@ jobs:
       RUST_VERSION: ${{ matrix.rust-version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-    - uses: dtolnay/rust-toolchain@master
+    - uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
       with:
         toolchain: ${{ matrix.rust-version }}
 
     - id: cache-rust
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
-    - uses: taiki-e/install-action@cargo-llvm-cov
+    - uses: taiki-e/install-action@0631aa6515c7d545823c67cfae7ef4fc7f490154 # v2.81.8
+      with:
+        tool: cargo-llvm-cov
 
     - run: cargo llvm-cov --all-features --codecov --output-path codecov.json
 
-    - uses: codecov/codecov-action@v3
+    - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: codecov.json
@@ -87,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Decide whether the needed jobs succeeded or failed
-        uses: re-actors/alls-green@release/v1
+        uses: re-actors/alls-green@05ac9388f0aebcb5727afa17fcccfecd6f8ec5fe # v1.2.2
         with:
           jobs: ${{ toJSON(needs) }}
 
@@ -98,12 +101,14 @@ jobs:
     environment: release
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
     - name: install rust stable
-      uses: dtolnay/rust-toolchain@stable
+      uses: dtolnay/rust-toolchain@3c5f7ea28cd621ae0bf5283f0e981fb97b8a7af9 # master (2026-03-27)
+      with:
+        toolchain: stable
 
-    - uses: Swatinem/rust-cache@v2
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
 
     - run: cargo publish
       env:


### PR DESCRIPTION
## Summary
Updates every action in `.github/workflows/ci.yml` to its latest release and pins it to a **full commit SHA** (with a `# vX.Y.Z` comment) for supply-chain safety. This also clears the Node 20 deprecation warnings GitHub flagged on recent runs.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v2 / v3 / v4 | **v6.0.3** |
| `actions/setup-python` | v5 | **v6.2.0** |
| `Swatinem/rust-cache` | v2 | **v2.9.1** |
| `pre-commit/action` | v3.0.0 | **v3.0.1** |
| `taiki-e/install-action` | `@cargo-llvm-cov` | **v2.81.8** (tool via `with: tool:`) |
| `codecov/codecov-action` | v3 | **v7.0.0** |
| `re-actors/alls-green` | `@release/v1` | **v1.2.2** |
| `dtolnay/rust-toolchain` | `@stable` / `@master` | pinned to `master` SHA |

## Notes
- `dtolnay/rust-toolchain` has no versioned releases — the git ref *is* the toolchain selector. Pinned to a commit SHA and the toolchain is now passed explicitly via `with: toolchain:` (`stable` for lint/release, `${{ matrix.rust-version }}` for the test matrix) to preserve behavior.
- `taiki-e/install-action` previously selected the tool via the `@cargo-llvm-cov` ref; now pinned to a release SHA with `with: tool: cargo-llvm-cov`.
- `codecov/codecov-action` v7 keeps the same inputs we use (`token`, `files`, `env_vars`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)