### PR TITLE
Fix nested JSON string access

### DIFF
--- a/src/rewrite.rs
+++ b/src/rewrite.rs
@@ -35,7 +35,7 @@ impl FunctionRewrite for JsonFunctionRewriter {
 /// extracting the right value type from JSON without the need to materialize the JSON union.
 fn optimise_json_get_cast(cast: &Cast) -> Option<Transformed<Expr>> {
     let scalar_func = extract_scalar_function(&cast.expr)?;
-    if scalar_func.func.name() != "json_get" {
+    if !is_json_get(scalar_func) {
         return None;
     }
     let func = match cast.field.data_type() {
@@ -71,9 +71,9 @@ fn unnest_json_calls(func: &ScalarFunction) -> Option<Transformed<Expr>> {
     let first_arg = outer_args_iter.next()?;
     let inner_func = extract_scalar_function(first_arg)?;
 
-    // both json_get and json_as_text would produce new JSON to be processed by the outer
-    // function so can be inlined
-    if !matches!(inner_func.func.name(), "json_get" | "json_as_text") {
+    // only json_get preserves a JSON value for the outer function. json_as_text returns SQL text,
+    // so flattening through it changes semantics for JSON strings that contain JSON.
+    if !is_json_get(inner_func) {
         return None;
     }
 
@@ -88,6 +88,10 @@ fn unnest_json_calls(func: &ScalarFunction) -> Option<Transformed<Expr>> {
     } else {
         None
     }
+}
+
+fn is_json_get(func: &ScalarFunction) -> bool {
+    func.func.inner().is::<crate::json_get::JsonGet>()
 }
 
 fn extract_scalar_function(expr: &Expr) -> Option<&ScalarFunction> {

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -875,6 +875,22 @@ async fn test_json_get_union_scalar() {
 }
 
 #[tokio::test]
+async fn test_json_as_text_nested_json_string() {
+    let sql = r#"select json_as_text(json_as_text('{"user_id":"{\"device_id\":\"abc\"}"}', 'user_id'), 'device_id')"#;
+    let batches = run_query(sql).await.unwrap();
+
+    assert_eq!(display_val(batches).await, (DataType::Utf8, "abc".to_string()));
+}
+
+#[tokio::test]
+async fn test_json_get_str_nested_json_string() {
+    let sql = r#"select json_get_str(json_as_text('{"user_id":"{\"device_id\":\"abc\"}"}', 'user_id'), 'device_id')"#;
+    let batches = run_query(sql).await.unwrap();
+
+    assert_eq!(display_val(batches).await, (DataType::Utf8, "abc".to_string()));
+}
+
+#[tokio::test]
 async fn test_json_get_nested_collapsed() {
     let sql = "select name, json_get(json_get(json_data, 'foo'), 0) as v from test";
     let expected = [
@@ -1393,7 +1409,7 @@ async fn test_plan_double_arrow_double_nested() {
     let lines = logical_plan(r"explain select json_data->>'foo'->>0 from test").await;
 
     let expected = [
-        "Projection: json_as_text(test.json_data, Utf8(\"foo\"), Int64(0)) AS json_data ->> 'foo' ->> 0",
+        "Projection: json_as_text(json_as_text(test.json_data, Utf8(\"foo\")), Int64(0)) AS json_data ->> 'foo' ->> 0",
         "  TableScan: test projection=[json_data]",
     ];
 
@@ -1466,7 +1482,7 @@ async fn test_plan_double_arrow_double_nested_cast() {
 
     // NB: json_as_text(..)::int is NOT the same as `json_get_int(..)`, hence the cast is not rewritten
     let expected = [
-        "Projection: CAST(json_as_text(test.json_data, Utf8(\"foo\"), Int64(0)) AS Int32) AS json_data ->> 'foo' ->> 0",
+        "Projection: CAST(json_as_text(json_as_text(test.json_data, Utf8(\"foo\")), Int64(0)) AS Int32) AS json_data ->> 'foo' ->> 0",
         "  TableScan: test projection=[json_data]",
     ];
 


### PR DESCRIPTION
## Summary

- Stop flattening nested JSON calls when the inner call is `json_as_text`
- Keep the existing `json_get(json_get(...))` unnest optimization intact
- Add regressions for extracting from JSON strings that contain valid nested JSON

## Why

`json_as_text` returns SQL text, not a preserved JSON value. Flattening `json_as_text(json_as_text(...), 'device_id')` into a single path lookup skips the intermediate unescaped JSON string and returns null for values like `{"user_id":"{\"device_id\":\"abc\"}"}`.

## Validation

- `cargo fmt`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`